### PR TITLE
fix: prevent double-award in reputation reconciliation on delete failure (#14692)

### DIFF
--- a/backend/api/src/services/reputationReconciliation.js
+++ b/backend/api/src/services/reputationReconciliation.js
@@ -78,31 +78,44 @@ export async function reconcileFailedReputationUpdates() {
       }
 
       try {
-        // Award first, then delete. Deleting before the award leaves a crash
-        // window where the pending row is gone and the driver never receives
-        // the points. Only remove the row once the award succeeded; if the
-        // delete fails after a successful award it is only logged (never
-        // re-queued) so the points cannot be awarded twice from the same row.
+        // Delete-then-award to prevent double-awarding on-chain points (#14692).
+        // awardReputationPoints is an irreversible on-chain action, so we only
+        // credit the driver AFTER the pending row has been removed from
+        // reputation_failures. If the delete fails, the row stays and is retried
+        // on the next cycle WITHOUT any points being credited — the safer failure
+        // mode versus an irreversible double-credit.
+        const { data: deletedRows, error: deleteError } = await supabaseAdmin
+          .from('reputation_failures')
+          .delete()
+          .eq('id', row.id)
+          .select('id');
+
+        if (deleteError || !deletedRows || deletedRows.length === 0) {
+          // Could not remove the pending row: do NOT award points. Bump
+          // retry_count so repeated delete failures eventually stop retrying.
+          const newRetryCount = (row.retry_count ?? 0) + 1;
+          await supabaseAdmin
+            .from('reputation_failures')
+            .update({
+              retry_count: newRetryCount,
+              last_error: `delete-failed-before-award: ${deleteError?.message ?? 'row not found'}`,
+              last_attempt_at: new Date().toISOString(),
+            })
+            .eq('id', row.id);
+          logger.warn(
+            `[reputation-reconciliation] Could not remove pending row ${row.id} before award; skipping to avoid double-award: ${deleteError?.message ?? 'row not found'}`
+          );
+          continue;
+        }
+
+        // Pending row removed successfully — safe to credit on-chain points
+        // exactly once.
         await awardReputationPoints(row.driver_wallet, row.stars);
         logger.info(`[reputation-reconciliation] Successfully retried reputation update for ${row.driver_wallet}`);
-
-        const { error: deleteError } = await supabaseAdmin.from('reputation_failures').delete().eq('id', row.id);
-        if (deleteError) {
-          // The award already succeeded but the pending row could not be removed.
-          // Bump retry_count so the row is eventually excluded from selection and is
-          // not re-awarded indefinitely if the delete keeps failing (issue #12332).
-          const newRetryCount = (row.retry_count ?? 0) + 1;
-          await supabaseAdmin.from('reputation_failures').upsert({
-            id: row.id,
-            driver_wallet: row.driver_wallet,
-            stars: row.stars,
-            retry_count: newRetryCount,
-            last_error: `delete-failed: ${deleteError.message}`,
-            last_attempt_at: new Date().toISOString(),
-          });
-          logger.warn(`[reputation-reconciliation] Award succeeded but failed to remove pending row ${row.id}: ${deleteError.message}`);
-        }
       } catch (err) {
+        // The award threw after the pending row was already deleted. Re-insert
+        // the pending row so the points can be retried. No points have been
+        // credited yet, so this cannot double-award.
         const newRetryCount = (row.retry_count ?? 0) + 1;
         await supabaseAdmin.from('reputation_failures').upsert({
           id: row.id,
@@ -112,7 +125,7 @@ export async function reconcileFailedReputationUpdates() {
           last_error: err.message,
           last_attempt_at: new Date().toISOString(),
         });
-        logger.warn(`[reputation-reconciliation] Retry ${newRetryCount}/${MAX_RETRIES} failed for ${row.driver_wallet}: ${err.message}`);
+        logger.warn(`[reputation-reconciliation] Award failed for ${row.driver_wallet} after removing pending row; re-queued for retry: ${err.message}`);
       } finally {
         // Release the per-row claim so a re-queued failure can be retried on
         // the next cycle instead of waiting for the 300s claim TTL to expire.

--- a/backend/api/test/unit/reputationReconciliation.test.js
+++ b/backend/api/test/unit/reputationReconciliation.test.js
@@ -40,6 +40,11 @@ function makeSupabaseMock() {
         })),
       })),
       delete: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          select: vi.fn(() => Promise.resolve({ data: [{ id: 'x' }], error: null })),
+        })),
+      })),
+      update: vi.fn(() => ({
         eq: vi.fn(() => Promise.resolve({ error: null })),
       })),
       upsert: vi.fn(() => Promise.resolve({ error: null })),
@@ -91,6 +96,11 @@ describe('reputationReconciliation', () => {
         })),
       })),
       delete: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          select: vi.fn(() => Promise.resolve({ data: [{ id: 'row-id' }], error: null })),
+        })),
+      })),
+      update: vi.fn(() => ({
         eq: vi.fn(() => Promise.resolve({ error: null })),
       })),
       upsert: vi.fn(() => Promise.resolve({ error: null })),
@@ -173,7 +183,29 @@ describe('reputationReconciliation', () => {
     await reconcileFailedReputationUpdates();
 
     expect(mockLogger.warn).toHaveBeenCalledWith(
-      expect.stringContaining('Retry 3/10 failed for 0xwallet2')
+      expect.stringContaining('Award failed for 0xwallet2 after removing pending row')
+    );
+  });
+
+  it('does NOT award on-chain points when the delete fails (#14692)', async () => {
+    mockRedisClient.set.mockResolvedValue('lock-value');
+    mockRedisClient.del.mockResolvedValue(1);
+    const row = { id: 'row-5', driver_wallet: '0xwallet5', stars: 4, retry_count: 0 };
+    const queryBuilder = withFailedReputations([row]);
+    // Simulate a delete failure: delete resolves but reports an error and no
+    // deleted rows, so the row remains and must NOT be re-awarded.
+    queryBuilder.delete.mockReturnValue({
+      eq: vi.fn(() => ({
+        select: vi.fn(() => Promise.resolve({ data: null, error: new Error('deadlock') })),
+      })),
+    });
+    mockAwardReputationPoints.mockResolvedValueOnce({ txHash: '0xtxhash' });
+
+    await reconcileFailedReputationUpdates();
+
+    expect(mockAwardReputationPoints).not.toHaveBeenCalled();
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Could not remove pending row row-5 before award')
     );
   });
 


### PR DESCRIPTION
## Problem

In `backend/api/src/services/reputationReconciliation.js`, the reconciliation loop awarded on-chain reputation points **first** and only then deleted the pending row. On a successful award, if the subsequent `delete` failed, the code `upsert`ed the same row back with `retry_count + 1`. Because the row stayed in `reputation_failures`, it was re-selected on the next cycle and **awarded again**. `awardReputationPoints` is an irreversible on-chain action, so a transient delete failure double-credits the driver (`retry_count` only reaches `MAX_RETRIES` after 10 cycles, allowing up to 10 double-awards). The inline comment claimed the row was "never re-queued", which the code contradicted.

## Fix

Reordered the operation to **delete-then-award** so the irreversible on-chain credit can only happen after the pending row has been successfully removed:
- `delete().eq(id).select('id')` is attempted first; award only proceeds if the row was actually removed (`data` returned, no error).
- If the delete fails, the row is left in place (with `retry_count` bumped via `update`) and points are **never** credited — the safer failure mode versus irreversible double-credit.
- If the award itself fails *after* the row was deleted, the pending row is re-`upsert`ed for retry; since nothing was credited yet, this cannot double-award.

This eliminates the crash window for double-award at the cost of a (recoverable, retryable) lost award when the on-chain call fails — the explicitly preferred trade-off for irreversible credits.

## Files changed

- `backend/api/src/services/reputationReconciliation.js` — flipped award/delete order, added delete-success guard, updated delete-failure handling to not credit points.
- `backend/api/test/unit/reputationReconciliation.test.js` — updated mocks for the new `delete().select()` / `update()` chain and the new award-failure log message; added a regression test asserting points are NOT awarded when the delete fails.

## Testing

- New unit test `does NOT award on-chain points when the delete fails (#14692)` verifies `awardReputationPoints` is never called when the delete errors, and that a warning is logged.
- Updated existing tests to match the new delete chain and log message.
- `node --check` passes on both the service and the test file.
- Note: full `npm ci`/`vitest` run could not be executed in this environment due to platform-specific (`openharmony`) dependency constraints, so the suite was verified by syntax check and logic review.

Closes #14692
