### PR TITLE
fix(paymentRoutes): invalidateBookingCaches is not defined

### DIFF
--- a/backend/api/src/routes/paymentRoutes.js
+++ b/backend/api/src/routes/paymentRoutes.js
@@ -37,6 +37,7 @@ import {
   submitEscrowRefund,
 } from '../services/escrow.js';
 import { sendPushNotification } from '../services/notificationService.js';
+import { invalidateBookingCaches } from '../utils/cacheInvalidation.js';
 
 const router = express.Router();
 


### PR DESCRIPTION
Closes #14802

## Problem

In `backend/api/src/routes/paymentRoutes.js` line 425, `invalidateBookingCaches()` is called but never imported (ESLint `no-undef`). The helper exists in `backend/api/src/utils/cacheInvalidation.js` but the import is missing — every payment-lock request throws `ReferenceError` after the escrow transaction succeeds, returning a 500 for a confirmed payment.

## Fix

Add the missing import:

```js
import { invalidateBookingCaches } from '../utils/cacheInvalidation.js';
```

Verified with `node --check` and ESLint.
