### PR TITLE
fix(HealthAggregator): remove orphan .catch line

### DIFF
--- a/backend/api/src/core/health/HealthAggregator.js
+++ b/backend/api/src/core/health/HealthAggregator.js
@@ -176,4 +176,3 @@ export class HealthAggregator {
   }
 }
 
-.catch(err => console.error("Promise.all failed:", err));


### PR DESCRIPTION
Closes #14819

## Problem

In `backend/api/src/core/health/HealthAggregator.js`, an orphaned line sits after the class closes (line 179):

```js
.catch(err => console.error("Promise.all failed:", err));
```

Copy-paste tail of an unrelated promise chain → `Parsing error: Unexpected token .` at line 179. The module cannot be loaded.

## Fix

Remove the orphaned `.catch(...)` line.

Verified with `node --check` and ESLint.
