### PR TITLE
fix(authRoutes): remove orphan .catch line

### DIFF
--- a/backend/api/src/routes/authRoutes.js
+++ b/backend/api/src/routes/authRoutes.js
@@ -446,5 +446,3 @@ router.post("/verify", async (req, res) => {
 export default router;
 
 // Resolves #2052: Refresh Token Rotation logic
-
-.catch(err => console.error("Promise.all failed:", err));


### PR DESCRIPTION
Closes #14820

## Problem

In `backend/api/src/routes/authRoutes.js`, an orphaned line sits after `export default router;` (line 450):

```js
.catch(err => console.error("Promise.all failed:", err));
```

Copy-paste tail of an unrelated promise chain → `Parsing error: Unexpected token .` at line 450. The module cannot be loaded.

## Fix

Remove the orphaned `.catch(...)` line.

Verified with `node --check` and ESLint.
