### PR TITLE
fix(staleOrderWorker): remove duplicate submitEscrowRefund import

### DIFF
--- a/backend/api/src/workers/staleOrderWorker.js
+++ b/backend/api/src/workers/staleOrderWorker.js
@@ -6,7 +6,6 @@ import { confirmEscrowRefund, submitEscrowRefund } from '../services/escrow.js';
 import { WorkerTracer } from '../core/telemetry/WorkerTracer.js';
 import spanFactory from '../core/telemetry/SpanFactory.js';
 import { OrderRepository } from '../repositories/orderRepository.js';
-import { submitEscrowRefund } from '../services/escrow.js';
 
 let staleOrderWorkerTask = null;
 let staleOrderRunning = false;


### PR DESCRIPTION
Closes #14821

## Problem

In `backend/api/src/workers/staleOrderWorker.js`, `submitEscrowRefund` is imported twice:

- line 5: `import { confirmEscrowRefund, submitEscrowRefund } from '../services/escrow.js';`
- line 9: `import { submitEscrowRefund } from '../services/escrow.js';`

Hard parse error: `Identifier 'submitEscrowRefund' has already been declared` at line 9. The worker cannot be loaded.

## Fix

Remove the duplicate import at line 9.

Verified with `node --check` and ESLint.
