### PR TITLE
security: require auth on eBPF/WASI/WASM/Snyk telemetry GET endpoints (#14691)

### DIFF
--- a/ebpf/routes.js
+++ b/ebpf/routes.js
@@ -39,7 +39,7 @@ const ebpfMetricsLimiter = rateLimit({
 // ============ System Metrics ============
 
 // System metrics
-router.get('/ebpf/metrics', ebpfMetricsLimiter, async (req, res) => {
+router.get('/ebpf/metrics', authenticate, requirePolicy('ebpf:manage'), ebpfMetricsLimiter, async (req, res) => {
     try {
         // In production: get metrics from eBPF
         const metrics = {
@@ -77,7 +77,7 @@ router.get('/ebpf/metrics', ebpfMetricsLimiter, async (req, res) => {
 });
 
 // System calls
-router.get('/ebpf/syscalls', ebpfMetricsLimiter, async (req, res) => {
+router.get('/ebpf/syscalls', authenticate, requirePolicy('ebpf:manage'), ebpfMetricsLimiter, async (req, res) => {
     try {
         // In production: read from BPF map
         const syscalls = {
@@ -102,7 +102,7 @@ router.get('/ebpf/syscalls', ebpfMetricsLimiter, async (req, res) => {
 });
 
 // Network stats
-router.get('/ebpf/network', ebpfMetricsLimiter, async (req, res) => {
+router.get('/ebpf/network', authenticate, requirePolicy('ebpf:manage'), ebpfMetricsLimiter, async (req, res) => {
     try {
         // In production: read from BPF map
         const network = {
@@ -124,7 +124,7 @@ router.get('/ebpf/network', ebpfMetricsLimiter, async (req, res) => {
 });
 
 // Security events
-router.get('/ebpf/security', ebpfMetricsLimiter, async (req, res) => {
+router.get('/ebpf/security', authenticate, requirePolicy('ebpf:manage'), ebpfMetricsLimiter, async (req, res) => {
     try {
         const events = [
             {
@@ -154,7 +154,7 @@ router.get('/ebpf/security', ebpfMetricsLimiter, async (req, res) => {
 });
 
 // Performance profile
-router.get('/ebpf/profile', ebpfMetricsLimiter, async (req, res) => {
+router.get('/ebpf/profile', authenticate, requirePolicy('ebpf:manage'), ebpfMetricsLimiter, async (req, res) => {
     try {
         const profile = {
             syscalls: {

--- a/wasm/routes.js
+++ b/wasm/routes.js
@@ -1,6 +1,8 @@
 import express from 'express';
 import edgeRuntime from './edge-runtime.js';
 import logger from '../backend/api/src/middleware/logger.js';
+import { authenticate } from '../backend/api/src/middleware/auth.js';
+import { requirePolicy } from '../backend/api/src/middleware/requirePolicy.js';
 
 const router = express.Router();
 
@@ -124,7 +126,7 @@ router.post('/wasm/eta', async (req, res) => {
 // against a stored, hashed OTP — never a client-supplied reference.
 
 // Get stats
-router.get('/wasm/stats', async (req, res) => {
+router.get('/wasm/stats', authenticate, requirePolicy('wasm:manage'), async (req, res) => {
     try {
         const stats = await edgeRuntime.getFunctionStats();
         res.json({


### PR DESCRIPTION
## Problem

The eBPF, WASI, WASM, and Snyk routers expose host-telemetry/security data via `GET` endpoints. In `origin/main`, the eBPF `GET` telemetry endpoints (`/ebpf/metrics`, `/ebpf/syscalls`, `/ebpf/network`, `/ebpf/security`, `/ebpf/profile`) and the WASM `/wasm/stats` endpoint had **no `authenticate`/`requirePolicy`** guard, diverging from their `POST` counterparts which already required auth. This allowed anonymous users to read system/security metrics (host security events, process execs, syscalls, network stats) — an unauthenticated infrastructure-internals disclosure. WASI and Snyk GET endpoints were already protected at the router level via `router.use(authenticate, requirePolicy(...))`.

## Fix

- eBPF: Added `authenticate, requirePolicy('ebpf:manage')` to all five `GET` telemetry handlers (`ebpf/routes.js`), matching the existing `POST` management endpoints.
- WASM: Added `authenticate, requirePolicy('wasm:manage')` to the `GET /wasm/stats` handler and imported the required middleware (`wasm/routes.js`).
- WASI / Snyk: Already enforce auth on every route (including `GET`) through `router.use(authenticate, requirePolicy('wasi:manage' | 'snyk:manage'))`, so no per-handler change was needed — verified against `origin/main`.

## Files changed

- `ebpf/routes.js` — applied `authenticate, requirePolicy('ebpf:manage')` to the 5 `GET` telemetry endpoints.
- `wasm/routes.js` — applied `authenticate, requirePolicy('wasm:manage')` to `GET /wasm/stats` and imported the middleware.

## Testing

- Verified with `git diff origin/main` that every `GET` telemetry endpoint across the four routers is now gated by `authenticate` + the corresponding `:manage` policy (WASI/Snyk via router-level middleware, eBPF/WASM via per-handler middleware).
- Confirmed the mutating/`POST` auth posture is now consistent with the read/`GET` posture.
- No behavioral change to authenticated callers; anonymous `GET` requests to these endpoints now return 401.

Closes #14691
