### PR TITLE
fix: prevent orphaned dispatched payouts in withdrawal settlement worker (#14686)

### DIFF
--- a/backend/api/src/services/wallet/payoutProvider.js
+++ b/backend/api/src/services/wallet/payoutProvider.js
@@ -91,3 +91,51 @@ export async function dispatchPayout({ driverId, withdrawal }) {
   logger.error(`[PayoutProvider] Provider "${provider}" is not wired up. Configure WITHDRAWAL_PAYOUT_WEBHOOK_URL.`);
   throw new Error(`Withdrawal payout provider "${provider}" is not supported yet.`);
 }
+
+/**
+ * Best-effort recovery of a payout's settlement reference from the provider.
+ *
+ * A withdraw can be left with `payout_attempted_at` set but `settlement_ref`
+ * NULL in the database when the persist between dispatch and completion fails
+ * (Issue #14686). As long as the payout actually left the platform we must be
+ * able to re-derive the reference rather than orphaning the driver's funds.
+ *
+ * Providers that support status lookup opt in via WITHDRAWAL_PAYOUT_STATUS_URL;
+ * the platform previously sent `reference: "w<withdrawalId>"` to the dispatch
+ * webhook, which the status endpoint can resolve back to a settlement_ref.
+ * When no status endpoint is configured (or the lookup fails) we return null so
+ * the caller can flag the row for manual reconciliation instead of guessing.
+ */
+export async function recoverSettlementRef({ withdrawalId }) {
+  const statusUrl = process.env.WITHDRAWAL_PAYOUT_STATUS_URL;
+  if (!statusUrl) {
+    return null;
+  }
+
+  try {
+    const response = await fetch(
+      `${statusUrl}${statusUrl.includes('?') ? '&' : '?'}reference=w${withdrawalId}`,
+      {
+        method: 'GET',
+        headers: { 'content-type': 'application/json' },
+        signal: AbortSignal.timeout(payoutTimeoutMs()),
+      },
+    );
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const body = await response.json().catch(() => null);
+    if (!body || typeof body !== 'object') {
+      return null;
+    }
+
+    return body.settlement_ref || body.reference || null;
+  } catch (err) {
+    logger.error(
+      `[PayoutProvider] Failed to recover settlement ref for withdrawal ${withdrawalId}: ${err.message}`,
+    );
+    return null;
+  }
+}

--- a/backend/api/src/workers/withdrawalSettlementWorker.js
+++ b/backend/api/src/workers/withdrawalSettlementWorker.js
@@ -3,12 +3,22 @@ import logger from "../middleware/logger.js";
 import {
   dispatchPayout,
   isPayoutProviderConfigured,
+  recoverSettlementRef,
 } from "../services/wallet/payoutProvider.js";
 import { WorkerTracer } from "../core/telemetry/WorkerTracer.js";
 
 const BATCH_LIMIT = 50;
 const SETTLE_RETRY_ATTEMPTS = 3;
 const SETTLE_RETRY_DELAYS_MS = [500, 1500, 3000];
+
+// Persisting the settlement_ref is what guarantees a dispatched payout is
+// never orphaned, so we retry harder (and longer) than the settle RPC itself.
+const RECORD_PERSIST_ATTEMPTS = 6;
+const RECORD_PERSIST_DELAYS_MS = [250, 500, 1000, 2000, 4000, 8000];
+
+// A row that has been claimed (payout_attempted_at set) but is still missing a
+// settlement_ref this long is almost certainly stuck and must be escalated.
+const RECONCILE_STUCK_AFTER_MS = 60 * 60 * 1000;
 
 let intervalId = null;
 
@@ -67,7 +77,7 @@ async function claimWithdrawal(withdrawalId) {
  */
 async function recordDispatchOutcome(withdrawalId, settlementRef) {
   let lastError = null;
-  for (let attempt = 1; attempt <= SETTLE_RETRY_ATTEMPTS; attempt += 1) {
+  for (let attempt = 1; attempt <= RECORD_PERSIST_ATTEMPTS; attempt += 1) {
     const { error } = await supabaseAdmin
       .from("wallet_transactions")
       .update({ settlement_ref: settlementRef })
@@ -78,8 +88,8 @@ async function recordDispatchOutcome(withdrawalId, settlementRef) {
       return;
     }
     lastError = error;
-    if (attempt < SETTLE_RETRY_ATTEMPTS) {
-      await sleep(SETTLE_RETRY_DELAYS_MS[attempt - 1]);
+    if (attempt < RECORD_PERSIST_ATTEMPTS) {
+      await sleep(RECORD_PERSIST_DELAYS_MS[attempt - 1]);
     }
   }
   // Even after retries the outcome could not be persisted. The in-memory
@@ -120,6 +130,22 @@ async function settleWithRetry(withdrawalId, settlementRef) {
   }
   throw new Error(
     `Failed to settle withdrawal ${withdrawalId}: ${lastError.message}`,
+  );
+}
+
+/**
+ * Escalates a withdrawal that was claimed (payout_attempted_at set) but is
+ * stuck without a settlement_ref and cannot be re-derived from the provider
+ * (Issue #14686). The row is NOT restored to wallet_confirmed — the payout may
+ * already have left the platform, so restoring would double-pay the driver.
+ * Instead we raise a reconciliation/DLQ alert so an operator can confirm the
+ * payout status against the provider and manually settle or fail the row.
+ * Silently `continue`-ing here is what previously orphaned the driver forever.
+ */
+async function flagForReconciliation(withdrawalId) {
+  logger.error(
+    `[WithdrawalSettlementWorker][RECONCILIATION-DLQ] Withdrawal ${withdrawalId} is stuck: payout was attempted but no settlement_ref could be recorded or re-derived. ` +
+      `Manual reconciliation required — do NOT restore reserved funds until the provider payout status is confirmed.`,
   );
 }
 
@@ -250,14 +276,44 @@ export async function settlePendingWithdrawals() {
     // never call fail_withdrawal_tx here — restoring wallet_confirmed would
     // double-pay the driver. Keep the row 'pending' and let the next sweep
     // retry the idempotent settle call. If the settlement reference is still
-    // missing, the row may have been claimed but the dispatch never produced a
-    // payout reference (crash window) — refuse to settle so the withdrawal is
-    // not falsely marked completed with no payout having left the platform.
+    // missing, the row may have been claimed but the settlement_ref persist
+    // failed on a previous sweep (Issue #14686). We must NOT silently skip it
+    // — that permanently orphans the driver's funds. Instead, re-derive the
+    // reference from the provider, and only escalate to reconciliation/DLQ when
+    // it genuinely cannot be recovered.
     if (!settlementRef) {
-      logger.warn(
-        `[WithdrawalSettlementWorker] Withdrawal ${withdrawal.id} was claimed but no payout settlement reference was recorded - refusing to settle, keeping funds reserved.`,
-      );
-      continue;
+      const attemptedAt = withdrawal.payout_attempted_at
+        ? Date.parse(withdrawal.payout_attempted_at)
+        : null;
+      const stuckMs = attemptedAt ? Date.now() - attemptedAt : Infinity;
+
+      if (stuckMs >= RECONCILE_STUCK_AFTER_MS) {
+        await flagForReconciliation(withdrawal.id);
+        continue;
+      }
+
+      const recovered = await recoverSettlementRef({
+        withdrawalId: withdrawal.id,
+      });
+
+      if (recovered) {
+        settlementRef = recovered;
+        logger.warn(
+          `[WithdrawalSettlementWorker] Withdrawal ${withdrawal.id} settlement_ref re-derived from provider (ref: ${recovered}) — persisting and settling.`,
+        );
+        try {
+          await recordDispatchOutcome(withdrawal.id, recovered);
+        } catch (recordErr) {
+          logger.error(
+            `[WithdrawalSettlementWorker] Withdrawal ${withdrawal.id} re-derived settlement_ref could not be persisted: ${recordErr.message}`,
+          );
+        }
+      } else {
+        logger.warn(
+          `[WithdrawalSettlementWorker] Withdrawal ${withdrawal.id} claimed but settlement_ref still unrecorded — retrying reconciliation on next sweep.`,
+        );
+        continue;
+      }
     }
 
     try {


### PR DESCRIPTION
## Problem

In `backend/api/src/workers/withdrawalSettlementWorker.js`, after `dispatchPayout` succeeds (money has left the platform) the `settlement_ref` is persisted by `recordDispatchOutcome`. If that persist fails **and** the same-sweep `settle_withdrawal_tx` also fails (e.g. a transient DB outage), the row is left with `status='pending'`, `payout_attempted_at` set, and `settlement_ref` NULL.

On the next sweep, `claimWithdrawal` returns false (already attempted) so the row is skipped, and the worker reads `settlement_ref` from DB as null and `continue`s. The driver is **permanently underpaid** even though the payout already left the platform — the money can never be marked settled or failed, and there was no alert.

## Fix

Three targeted changes eliminate the orphan path:

1. **Harder persist retry (point 1).** `recordDispatchOutcome` now retries with a dedicated, longer budget (`RECORD_PERSIST_ATTEMPTS = 6`, escalating backoff) so the `settlement_ref` write succeeds before the sweep moves on, rather than relying on the single bounded `settle` retry.
2. **Provider re-derivation (point 2).** Added `recoverSettlementRef` to `payoutProvider.js`, which best-effort re-derives the settlement reference from the provider via `WITHDRAWAL_PAYOUT_STATUS_URL` (the platform previously sent `reference: "w<id>"`). When the worker finds a claimed row with a missing `settlement_ref`, it re-derives, persists, and settles it instead of skipping.
3. **Reconciliation / DLQ alert (point 3).** Added `flagForReconciliation`, which raises a high-severity `RECONCILIATION-DLQ` alert for rows that are stuck (`payout_attempted_at` set, `settlement_ref` still NULL beyond `RECONCILE_STUCK_AFTER_MS`). Funds are intentionally **not** restored (the payout may have left the platform, so restoring would double-pay the driver); an operator confirms provider status and settles/fails manually.

The previous silent `continue` on a missing `settlement_ref` is replaced with: re-derive → persist → settle; only escalate to reconciliation when it genuinely cannot be recovered.

## Files changed

- `backend/api/src/workers/withdrawalSettlementWorker.js` — stronger persist retry, provider re-derivation on the claimed-but-unrecorded path, and `RECONCILIATION-DLQ` escalation; added `recoverSettlementRef` import and related constants.
- `backend/api/src/services/wallet/payoutProvider.js` — added `recoverSettlementRef` for best-effort settlement-reference recovery from the provider.

## Testing

- `node --check` passes on both modified files.
- Logic review: the orphan scenario (persist fails + settle fails in one sweep) now recovers on the next sweep via `recoverSettlementRef`, and if unrecoverable, surfaces a reconciliation alert instead of silently dropping the row.
- Note: the repo's `eslint`/`vitest` suites could not be executed in this environment because `node_modules` is not installed in the worktree; the change is limited to the settlement worker and payout provider and preserves existing fail-closed behavior (no `fail_withdrawal_tx` is called on the claimed path).

Closes #14686
