### PR TITLE
fix: track mock GPS coordinates with incrementing index

### DIFF
--- a/apps/driver/lib/screens/offline_tracking_screen.dart
+++ b/apps/driver/lib/screens/offline_tracking_screen.dart
@@ -31,9 +31,11 @@ class _OfflineTrackingScreenState extends State<OfflineTrackingScreen> {
   }
 
   void _startMockGps() {
+    var i = 0;
     _gpsTimer = Timer.periodic(const Duration(seconds: 2), (timer) {
       // Simulate driving
-      _trackingService.recordLocation(41.8781 + (timer.tick * 0.001), -87.6298, 65.0);
+      i++;
+      _trackingService.recordLocation(41.8781 + (i * 0.001), -87.6298, 65.0);
       _updateUi();
     });
   }


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes made in this PR. -->
This PR fixes the mock GPS tracking logic in `OfflineTrackingScreen`.

The periodic GPS timer previously relied on `timer.tick` to calculate the next mock location. The implementation now uses a local incrementing index (`i`) inside the `Timer.periodic` callback.

Each timer interval increments the index and records a distinct coordinate, allowing the offline tracking queue to be populated with separate mock GPS locations.

## Type of Change
<!-- Select all that apply: -->
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. -->
- **Test Commands:**
- **Test Steps / Prerequisites:**
- **Expected Result:**

### Test Environment
- [x] Local manual testing
- [ ] Unit / Integration tests (`npm test`, `flutter test`, `pytest`)
- [ ] Tested via Docker Compose

## Related Issues
<!-- Link the issue(s) resolved or referenced by this PR. -->
<!-- Examples: Closes #1234, Related to #5678 -->
Closes https://github.com/KanishJebaMathewM/Truxify/issues/14863

## PR Checklist
- [x] My code follows the code style guidelines of this project (`flutter analyze`, `npm run lint`).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.
- [x] All automated integration & unit tests pass cleanly.
