### PR TITLE
fix: renew per-order escrow Redis lock TTL to prevent double payout (#14681)

### DIFF
--- a/backend/api/src/lib/redisLock.js
+++ b/backend/api/src/lib/redisLock.js
@@ -101,6 +101,55 @@ export async function renewLock(resourceKey, lockValue, ttlMs = 30_000) {
 }
 
 /**
+ * Renews the lock on a fixed interval while a long-running async task holds
+ * the critical section, so the lock cannot silently lapse mid-operation (e.g.
+ * while awaiting a slow on-chain `waitForConfirmation()`).
+ *
+ * This is the fix for concurrency issue #14681: per-order escrow locks were
+ * acquired with a fixed TTL but never renewed, so a blockchain confirmation
+ * that outlived the TTL let a second sweep re-lock and double-submit a payout.
+ *
+ * The renewal runs on `intervalMs` (default 10 s, always clamped to be shorter
+ * than `ttlMs`). Each renewal only succeeds if we still own the lock; if the
+ * lock is lost the timer keeps firing harmlessly (renewLock returns false) and
+ * the task itself must detect the lost lock. The timer is always cleared in a
+ * `finally` so it never outlives the task.
+ *
+ * @param {string}      resourceKey
+ * @param {string|null} lockValue   The UUID returned by acquireLock; if falsy, no renewal (pass-through)
+ * @param {number}      ttlMs       TTL to extend to on each renewal
+ * @param {() => Promise<T>} asyncFn  The critical-section task
+ * @param {number}      [intervalMs] Renewal cadence (default 10 000 ms)
+ * @returns {Promise<T>} the task's result
+ * @template T
+ */
+export const DEFAULT_LOCK_RENEWAL_INTERVAL_MS = 10_000;
+
+export async function withLockRenewal(resourceKey, lockValue, ttlMs, asyncFn, intervalMs = DEFAULT_LOCK_RENEWAL_INTERVAL_MS) {
+  if (!resourceKey || !lockValue || typeof asyncFn !== 'function') {
+    return asyncFn();
+  }
+
+  // Never renew less often than half the TTL, so at least one renewal lands
+  // before the lock could expire even if a tick is delayed.
+  const renewalIntervalMs = Math.max(Math.min(intervalMs, Math.floor(ttlMs / 2)), 1_000);
+
+  const timer = setInterval(() => {
+    // Fire-and-forget: renewLock logs and returns false on failure; a missed
+    // tick does not abort the task, it only risks the lock lapsing.
+    void renewLock(resourceKey, lockValue, ttlMs);
+  }, renewalIntervalMs);
+  // Don't keep the event loop alive solely for lock renewal.
+  timer.unref?.();
+
+  try {
+    return await asyncFn();
+  } finally {
+    clearInterval(timer);
+  }
+}
+
+/**
  * Releases a distributed lock **only if** we still own it.
  *
  * Uses an atomic Lua script (GET + DEL) so a slow holder cannot accidentally

--- a/backend/api/src/services/escrowFundingReconciliation.js
+++ b/backend/api/src/services/escrowFundingReconciliation.js
@@ -1,7 +1,7 @@
 import { redisClient, supabaseAdmin } from '../config/db.js';
 import logger from '../middleware/logger.js';
 import { submitEscrowRefund, getEscrowBooking } from './escrow.js';
-import { acquireLock, renewLock, releaseLock } from '../lib/redisLock.js';
+import { acquireLock, renewLock, releaseLock, withLockRenewal } from '../lib/redisLock.js';
 import { sendPushNotification } from './notificationService.js';
 
 // Two-phase acceptance sweeper (#5724): orders that reached escrow_status
@@ -33,7 +33,7 @@ function dueForRetry(order) {
 
 async function finalizeOrRevert(order, orderRepository) {
   const lockKey = `escrow_lock:${order.id}`;
-  const lockValue = await acquireLock(lockKey, 30000);
+  const lockValue = await acquireLock(lockKey, 120000);
   if (!lockValue) {
     logger.info(`[escrow-funding] Order ${order.order_display_id} locked by another process, skipping.`);
     return;
@@ -159,7 +159,12 @@ async function finalizeOrRevert(order, orderRepository) {
     }
 
     try {
-      await refundResult.waitForConfirmation();
+      // Keep the per-order lock alive while the on-chain confirmation runs so
+      // the TTL cannot lapse and let a concurrent sweep double-submit the
+      // refund (issue #14681).
+      await withLockRenewal(lockKey, lockValue, 120000, async () => {
+        await refundResult.waitForConfirmation();
+      });
     } catch (err) {
       logger.error(
         `[escrow-funding] Refund confirmation failed for ${order.order_display_id}: ${err.message}`

--- a/backend/api/src/services/escrowRefundReconciliation.js
+++ b/backend/api/src/services/escrowRefundReconciliation.js
@@ -1,7 +1,7 @@
 import { redisClient } from '../config/db.js';
 import logger from '../middleware/logger.js';
 import { confirmEscrowRefund, submitEscrowRefund, submitEscrowCancelWithPenalty, paisaToMaticWei, getEscrowBooking, getEscrowBookingId } from './escrow.js';
-import { acquireLock, releaseLock } from '../lib/redisLock.js';
+import { acquireLock, renewLock, releaseLock, withLockRenewal } from '../lib/redisLock.js';
 import os from 'os';
 
 const RECONCILIATION_EVENTS = {
@@ -27,16 +27,19 @@ export async function reconcilePendingEscrowRefunds(orderRepository) {
   }
   if (reconciliationRunning) return;
   reconciliationRunning = true;
-  let globalLockAcquired = false;
+  let globalLockValue = null;
 
   try {
     if (redisClient) {
       try {
-        globalLockAcquired = await redisClient.set(LOCK_KEY, process.pid.toString(), 'NX', 'EX', LOCK_TTL_SECONDS);
+        // Use the owner-token pattern so the lock can only be extended or
+        // released by its owner (issue #14681). The previous unconditional
+        // `expire`/`del` let two sweeps run at once.
+        globalLockValue = await acquireLock(LOCK_KEY, LOCK_TTL_SECONDS * 1000);
       } catch (err) {
         logger.warn({ err }, '[escrow-reconciliation] Failed to acquire reconciliation lock, proceeding without lock');
       }
-      if (!globalLockAcquired) {
+      if (!globalLockValue) {
         logger.info('[escrow-reconciliation] Global lock held by another instance, skipping batch pull.');
         return;
       }
@@ -65,16 +68,16 @@ export async function reconcilePendingEscrowRefunds(orderRepository) {
         }
       }
 
-      if (globalLockAcquired && redisClient) {
+      if (globalLockValue) {
         try {
-          await redisClient.expire(LOCK_KEY, LOCK_TTL_SECONDS);
+          await renewLock(LOCK_KEY, globalLockValue, LOCK_TTL_SECONDS * 1000);
         } catch (err) {
           logger.warn('[escrow-reconciliation] Failed to refresh lock:', err.message);
         }
       }
 
       const lockKey = `escrow_lock:${order.id}`;
-      const lockValue = await acquireLock(lockKey, 30000);
+      const lockValue = await acquireLock(lockKey, 120000);
       if (!lockValue) {
         logger.info(`[escrow-reconciliation] Order ${order.order_display_id} locked by another process (API or Job), skipping.`);
         continue;
@@ -171,7 +174,13 @@ export async function reconcilePendingEscrowRefunds(orderRepository) {
               `Escrow refund for ${order.order_display_id} could not be submitted on-chain (no confirmation available).`
             );
           }
-          receipt = await submitted.waitForConfirmation();
+          // Keep the per-order lock alive while the (slow) on-chain
+          // confirmation runs, otherwise the TTL can lapse mid-transaction and
+          // a concurrent sweep double-submits the refund (issue #14681).
+          receipt = await withLockRenewal(lockKey, lockValue, 120000, async () => {
+            const r = await submitted.waitForConfirmation();
+            return r;
+          });
           refundTxHash = receipt.hash ?? submitted.txHash;
         } else {
           receipt = await confirmEscrowRefund(refundTxHash);
@@ -215,9 +224,9 @@ export async function reconcilePendingEscrowRefunds(orderRepository) {
       }
     }
   } finally {
-    if (globalLockAcquired && redisClient) {
+    if (globalLockValue) {
       try {
-        await redisClient.del(LOCK_KEY);
+        await releaseLock(LOCK_KEY, globalLockValue);
       } catch (err) {
         logger.warn('[escrow-reconciliation] Failed to release global lock:', err.message);
       }

--- a/backend/api/src/services/escrowReleaseReconciliation.js
+++ b/backend/api/src/services/escrowReleaseReconciliation.js
@@ -1,7 +1,7 @@
 import os from 'os';
 import { supabaseAdmin } from '../config/db.js';
 import { escrowRelease, getEscrowBooking, getEscrowBookingId, resolveExpectedDepositAmount } from './escrow.js';
-import { acquireLock, releaseLock, renewLock, LockAcquisitionError } from '../lib/redisLock.js';
+import { acquireLock, releaseLock, renewLock, withLockRenewal, LockAcquisitionError } from '../lib/redisLock.js';
 import logger from '../middleware/logger.js';
 
 /**
@@ -31,7 +31,7 @@ import logger from '../middleware/logger.js';
 const DEFAULT_INTERVAL_MS = 60_000;
 const GLOBAL_LOCK_KEY = 'escrow:release:reconciliation:lock';
 const GLOBAL_LOCK_TTL_MS = 120_000;
-const ORDER_LOCK_TTL_MS = 60_000;
+const ORDER_LOCK_TTL_MS = 120_000;
 const MAX_RETRIES = 10;
 
 let reconciliationTimer = null;
@@ -91,7 +91,12 @@ export async function reconcilePendingEscrowReleases(orderRepository) {
       }
 
       try {
-        await finalizeReleasedOrder(order, orderRepository);
+        // Keep the per-order lock alive while the on-chain release +
+        // finalization runs, otherwise the TTL can lapse mid-transaction and a
+        // concurrent sweep double-submits the payout (issue #14681).
+        await withLockRenewal(orderLockKey, orderLockValue, ORDER_LOCK_TTL_MS, async () => {
+          await finalizeReleasedOrder(order, orderRepository);
+        });
       } catch (err) {
         logger.error(
           `[escrow-release-reconciliation] Finalization failed for order ${order.order_display_id}:`,


### PR DESCRIPTION
## Problem

The escrow reconciliation workers acquire a per-order Redis lock `escrow_lock:${order.id}` with a fixed TTL (30s for refund/funding, 60s for release) and then perform a slow on-chain operation (`submitEscrowRefund` / `submitEscrowCancelWithPenalty` / `escrowRelease` followed by `waitForConfirmation()`). Blockchain confirmation routinely exceeds the lock TTL under congestion. The per-order lock was **never renewed** during that window, so once the TTL expired a second concurrent sweep re-acquired `escrow_lock:${order.id}` and re-submitted the same on-chain transfer — a direct financial double-payout, since these on-chain calls are not idempotent.

Additionally, `escrowRefundReconciliation.js` used an unconditional `redisClient.set(NX)` + `expire`/`del` global lock keyed on `process.pid`, which lets two sweeps run at once (no owner token).

## Fix

- Added `withLockRenewal()` to `lib/redisLock.js` — wraps a long-running async task and periodically `PEXPIRE`s the lock via the existing owner-token `renewLock()` Lua script (interval clamped below the TTL), keeping the lock alive for the whole on-chain step.
- Wrapped the `waitForConfirmation()` (and the release finalization) critical sections in all three reconciliation workers with `withLockRenewal(lockKey, lockValue, ttl)`.
- Raised the per-order lock TTLs to 120s (above worst-case confirmation) so a single renewal tick in a congested window still covers the operation.
- Replaced the unconditional `set`/`expire`/`del` global lock in `escrowRefundReconciliation.js` with the owner-token `acquireLock`/`renewLock`/`releaseLock` pattern so two sweeps cannot run simultaneously.

## Files changed

- `backend/api/src/lib/redisLock.js` — new `withLockRenewal()` helper + `DEFAULT_LOCK_RENEWAL_INTERVAL_MS`.
- `backend/api/src/services/escrowRefundReconciliation.js` — owner-token global lock; per-order lock TTL 30s→120s; `waitForConfirmation` wrapped with renewal.
- `backend/api/src/services/escrowFundingReconciliation.js` — per-order lock TTL 30s→120s; `waitForConfirmation` wrapped with renewal.
- `backend/api/src/services/escrowReleaseReconciliation.js` — per-order lock TTL 60s→120s; finalization wrapped with renewal.

## Testing

- `node --check` passes on all four modified files.
- No behavioral change when the lock is not held (`withLockRenewal` passes through when `lockValue` is falsy / Redis unavailable).
- Existing reconciliation flows remain structurally unchanged; only the lock TTL is kept alive during the slow on-chain confirmation.

Closes #14681
