### PR TITLE
fix: preserve longitude in offline GPS geohash

### DIFF
--- a/apps/driver/lib/services/offline_tracking_service.dart
+++ b/apps/driver/lib/services/offline_tracking_service.dart
@@ -11,7 +11,9 @@ class OfflineTrackingService {
 
   void recordLocation(double lat, double lon, double speedMph) {
     // Mock geohash generation (simplified for mock purposes)
-    final mockGeohash = 'dp3w${(lat * 100).toInt() % 100}'; 
+    final latPart = (lat * 10000).toInt() % 100000;
+    final lonPart = (lon * 10000).toInt() % 100000;
+    final mockGeohash = 'dp3w${latPart}_$lonPart';
     
     final loc = GeohashLocation(
       geohash: mockGeohash,


### PR DESCRIPTION
## Description

by updating the mock geohash generation in `OfflineTrackingService` to include both latitude and longitude.

Previously, the generated geohash only used latitude, causing distinct GPS locations that differed in longitude to collapse into the same bucket. This change generates the mock geohash using quantized latitude and longitude values so distinct coordinate pairs remain distinguishable in the offline tracking queue.

## Type of Change

- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?

- **Test Commands:** Local manual verification
- **Test Steps / Prerequisites:** Tested distinct latitude and longitude coordinate values to verify that different GPS points generate different mock geohash values.
- **Expected Result:** Distinct GPS coordinates remain distinguishable and are not collapsed due to longitude being ignored.

### Test Environment

- [x] Local manual testing
- [ ] Unit / Integration tests (`npm test`, `flutter test`, `pytest`)
- [ ] Tested via Docker Compose

## Related Issues

Closes https://github.com/KanishJebaMathewM/Truxify/issues/14864

## PR Checklist

- [x] My code follows the code style guidelines of this project (`flutter analyze`, `npm run lint`).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.
- [ ] All automated integration & unit tests pass cleanly.