### PR TITLE
contract: enforce quadratic cost against cumulative votes in DAO.voteQuadratic (#14683)

### DIFF
--- a/blockchain/contracts/DAO.sol
+++ b/blockchain/contracts/DAO.sol
@@ -72,10 +72,14 @@ contract DAO is Ownable {
         require(block.timestamp < proposal.votingDeadline, "Voting period ended");
         require(_votes > 0, "Votes must be > 0");
 
-        uint256 tokenCost = _votes * _votes;
+        uint256 oldVotes = votesCast[_proposalId][msg.sender];
+        uint256 newVotes = oldVotes + _votes;
+        uint256 newCost = newVotes * newVotes;
+        uint256 oldCost = oldVotes * oldVotes;
+        uint256 tokenCost = newCost - oldCost;
         require(governanceToken.transferFrom(msg.sender, address(this), tokenCost), "Token transfer failed");
 
-        votesCast[_proposalId][msg.sender] += _votes;
+        votesCast[_proposalId][msg.sender] = newVotes;
         tokensHeld[_proposalId][msg.sender] += tokenCost;
         proposal.voteCount += _votes;
 
@@ -84,8 +88,9 @@ contract DAO is Ownable {
 
     /**
      * @dev Releases the escrowed governance tokens for a voter on a proposal.
-     * Refunds the exact sum of per-call quadratic costs (tokensHeld), never the
-     * square of the accumulated vote total, so the shared pool cannot be drained.
+     * Refunds the cumulative quadratic cost escrowed across all vote calls for
+     * this (voter, proposal) pair, which equals the square of the final
+     * accumulated vote total, so the shared pool cannot be drained.
      */
     function releaseVotes(uint256 _proposalId) external {
         uint256 held = tokensHeld[_proposalId][msg.sender];


### PR DESCRIPTION
## Problem

`DAO.voteQuadratic` charged only `_votes * _votes` per call and added to `votesCast[_proposalId][msg.sender]` each time, allowing the same address to vote an unlimited number of times on the same proposal. A holder wanting voting power `P` could call `voteQuadratic(1)` `P` times, paying a total of `P` tokens instead of `P²` — collapsing the quadratic cost curve to linear and letting wealthy holders buy near-linear governance power.

## Fix

Track the cumulative voting power per (voter, proposal) and charge the *difference* in quadratic cost on each call: `newTotal² - oldTotal²`, where `newTotal = oldVotes + _votes`. Voting remains additive (merged), but the total tokens escrowed always equals the square of the final accumulated vote total, exactly matching true quadratic voting regardless of how votes are split across calls. Updated the `releaseVotes` doc comment to reflect that refunds now equal the final accumulated vote total squared.

## Files changed

- `blockchain/contracts/DAO.sol` (`voteQuadratic`, lines 68–83; `releaseVotes` doc comment)

## Testing

- Manual trace: calling `voteQuadratic(1)` `P` times now escrows `1 + 3 + 5 + ... + (2P-1) = P²` tokens versus the old `P` tokens.
- Confirmed `votesCast` accumulates to `P`, `tokensHeld` accumulates to `P²`, and `releaseVotes` refunds the full `P²` escrowed.

Closes #14683
