### PR TITLE
fix(profileService): remove duplicate isValidCachedProfile import

### DIFF
--- a/backend/api/src/services/profileService.js
+++ b/backend/api/src/services/profileService.js
@@ -4,7 +4,6 @@ import {
   getCachedSupabaseProfile, setCachedSupabaseProfile, isValidCachedProfile,
   getCachedCustomerStats, setCachedCustomerStats,
   getCachedDriverDetails, setCachedDriverDetails,
-  isValidCachedProfile,
 } from '../lib/profileCache.js';
 import logger from '../middleware/logger.js';
 


### PR DESCRIPTION
Closes #14878

## Problem

`backend/api/src/services/profileService.js` imports `isValidCachedProfile` twice from `../lib/profileCache.js` (lines 4 and 7) → hard parse error `Identifier 'isValidCachedProfile' has already been declared`. The module cannot be loaded.

## Fix

Remove the duplicate import at line 7.

Verified with `node --check` and ESLint.

GSSOC
