### PR TITLE
contract: bind zkEVM L2 sigs to chainId and enforce sequential nonces (#14684)

### DIFF
--- a/blockchain/contracts/zkEVM.sol
+++ b/blockchain/contracts/zkEVM.sol
@@ -126,21 +126,15 @@ contract zkEVM is Ownable, ReentrancyGuard, Pausable {
             require(!usedNonces[from][nonce], "Nonce already used");
             require(currentState.balances[from] >= value + gasPrice * gasLimit, "Insufficient balance");
 
-            // Verify signature (same digest as executeTransaction)
-            bytes32 txHashForSig = keccak256(abi.encodePacked(from, to, value, data, nonce, gasPrice, gasLimit));
+            // Verify signature (same bound digest as executeTransaction)
+            bytes32 txHashForSig = _txHash(from, to, value, data, nonce, gasPrice, gasLimit);
             require(_verifySignature(txHashForSig, signature, from), "Invalid signature");
 
             processedTxHashes[txHash] = true;
-<<<<<<< HEAD
-            usedNonces[from][nonce] = true;
-
-            // Same per-tx signature/nonce/balance checks as the single-tx path.
-=======
 
             // Same per-tx signature/nonce/balance checks as the single-tx path.
             // _applyTx marks the nonce used; do not mark it before the call or
             // _applyTx's own "Nonce already used" check reverts every batch.
->>>>>>> upstream/main
             _applyTx(from, to, value, data, nonce, gasPrice, gasLimit, signature);
             txHashes[i] = txHash;
         }
@@ -268,6 +262,7 @@ contract zkEVM is Ownable, ReentrancyGuard, Pausable {
     ) internal returns (uint256 txId, bytes32 txHash) {
         // CHECKS
         require(to != address(0), "Invalid address");
+        require(nonce == currentState.nonces[from], "bad nonce");
         require(!usedNonces[from][nonce], "Nonce already used");
         require(currentState.balances[from] >= value + gasPrice * gasLimit, "Insufficient balance");
 
@@ -317,19 +312,16 @@ contract zkEVM is Ownable, ReentrancyGuard, Pausable {
         uint256 nonce,
         uint256 gasPrice,
         uint256 gasLimit
-    ) internal pure returns (bytes32) {
-        return keccak256(abi.encodePacked(from, to, value, data, nonce, gasPrice, gasLimit));
+    ) internal view returns (bytes32) {
+        return keccak256(abi.encodePacked(block.chainid, address(this), from, to, value, data, nonce, gasPrice, gasLimit));
     }
 
     function _verifyProof(bytes calldata proof) internal view returns (bool) {
-<<<<<<< HEAD
-=======
         // A real Groth16/STARK verifier must be configured before withdrawals
         // or batch execution can ever succeed. Reverting here (instead of
         // silently failing on the placeholder) makes misconfigurations loud so
         // user funds are never stranded by an unconfigured proof check.
         require(verifier != address(0), "zkEVM: verifier not configured");
->>>>>>> upstream/main
         require(proof.length > 0, "Empty proof");
         (uint[2] memory a, uint[2][2] memory b, uint[2] memory c, uint[2] memory input) =
             abi.decode(proof, (uint[2], uint[2][2], uint[2], uint[2]));


### PR DESCRIPTION
## Problem

In `blockchain/contracts/zkEVM.sol`, L2 transaction signatures are vulnerable to cross-chain replay and nonces are non-sequential:

1. **Cross-chain replay** — `_verifySignature` (and the batch-path digest) hashes only `keccak256(from, to, value, data, nonce, gasPrice, gasLimit)`. It omits `block.chainid` and `address(this)`, so a signature valid on one deployment is valid on any other chain/rollup sharing the same code.
2. **Non-sequential nonces** — `_applyTx` only checks `!usedNonces[from][nonce]`; it never requires `nonce == currentState.nonces[from]`. A user can submit arbitrary/skipped nonces out of order, enabling state reordering.
3. The file also contained unresolved merge-conflict markers, including a premature `usedNonces[from][nonce] = true;` in `executeBatch` that would make `_applyTx`'s own nonce check revert every batch.

## Fix

- Bind the canonical tx digest to the chain and contract: `_txHash` now computes `keccak256(abi.encodePacked(block.chainid, address(this), from, to, value, data, nonce, gasPrice, gasLimit))` (changed `pure` → `view`).
- Use the same bound digest for signature verification in both `executeTransaction` (via `_applyTx`) and `executeBatch` (removed the duplicate bare digest).
- Enforce sequential nonces in `_applyTx`: added `require(nonce == currentState.nonces[from], "bad nonce");` before the used-nonce check. The batch path inherits this via `_applyTx`.
- Resolved the merge conflicts: removed the premature `usedNonces[from][nonce] = true;` in `executeBatch` (kept the upstream/main explanatory comment) and kept the `require(verifier != address(0), ...)` guard in `_verifyProof`.

## Files changed

- `blockchain/contracts/zkEVM.sol`

## Testing

- Manual review of `executeTransaction` / `executeBatch` / `_applyTx` / `_txHash` / `_verifyProof` paths confirms the signed digest now includes `(chainid, this)` and that every applied tx must use the account's current sequential nonce.
- A signature produced for one `chainid`/`address(this)` no longer verifies on a different deployment.
- Resolved merge-conflict markers verified absent (`git grep` for `<<<<<<<` / `>>>>>>>`).
- Note: full Solidity compilation was not run (build tooling/node_modules not installed in this environment); the change is limited to digest composition and a single nonce assertion.

Closes #14684


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved batch transaction validation for more reliable nonce handling.
  * Strengthened transaction signatures by binding them to the intended network and contract.
  * Improved proof validation to reject incomplete verification configurations safely.
  * Reduced the risk of invalid or replayed transactions being accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->