### PR TITLE
fix(keyRotationService): use supabase client in logKeyRotationEvent

### DIFF
--- a/backend/api/src/services/security/keyRotationService.js
+++ b/backend/api/src/services/security/keyRotationService.js
@@ -240,7 +240,7 @@ class KeyRotationService {
 
   async logKeyRotationEvent(userId, walletAddress, reason, status, errorMessage = null, requestIp = null) {
     try {
-      await client
+      await supabase
         .from('key_rotation_audit_log')
         .insert([{
           user_id: userId,


### PR DESCRIPTION
Closes #14880

## Problem

`backend/api/src/services/security/keyRotationService.js` calls `client.from('key_rotation_audit_log')...` in `logKeyRotationEvent`, but `client` is never defined (ESLint `no-undef`). Every other DB call in the module uses the imported `supabase` client. Logging the first key-rotation audit event throws `ReferenceError`.

## Fix

Use the module's existing `supabase` client.

Verified with `node --check` and ESLint.

GSSOC
