### PR TITLE
fix(authRoutes): add missing jsonwebtoken import

### DIFF
--- a/backend/api/src/routes/authRoutes.js
+++ b/backend/api/src/routes/authRoutes.js
@@ -41,6 +41,7 @@
  */
 
 import express from "express";
+import jwt from "jsonwebtoken";
 import rateLimit from "express-rate-limit";
 import { authenticate } from "../middleware/auth.js";
 import {


### PR DESCRIPTION
Closes #14881

## Problem

`backend/api/src/routes/authRoutes.js` uses `jwt.sign(...)` in the `/auth/verify` route but never imports `jwt` (ESLint `no-undef`). Every `/auth/verify` request throws `ReferenceError: jwt is not defined`. `jsonwebtoken@^9.0.0` is already a dependency, imported the same way in `auth.js` and `tracker.js`.

## Fix

Add `import jwt from "jsonwebtoken";`.

Verified with `node --check` and ESLint. Note: full-file `node --check` also requires the pre-existing orphan `.catch` line at the end of `authRoutes.js` to be removed (separate PR #14866 addresses it); the two changes are in different parts of the file and merge cleanly.

GSSOC
