### PR TITLE
fix: compute refund penalty from pre-cancel status in reconciliation (#14687)

### DIFF
--- a/backend/api/src/repositories/orderRepository.js
+++ b/backend/api/src/repositories/orderRepository.js
@@ -606,7 +606,7 @@ export class OrderRepository {
   async findStaleFundingOrders(cutoff, { offset = 0, limit = 1000 } = {}) {
     return this._retryableQuery(() => this.supabase
       .from('orders')
-      .select('id, order_display_id, customer_id, escrow_booking_id, escrow_amount_wei, pending_bid_acceptance, escrow_funding_attempts, escrow_funding_last_attempt_at')
+      .select('id, order_display_id, customer_id, escrow_booking_id, escrow_amount_wei, status, cancellation_fee, total_amount, pending_bid_acceptance, escrow_funding_attempts, escrow_funding_last_attempt_at')
       .eq('escrow_status', 'funding')
       .not('pending_bid_acceptance', 'is', null)
       .or('escrow_funding_attempts.lt.10,escrow_funding_attempts.is.null')

--- a/backend/api/src/services/escrowFundingReconciliation.js
+++ b/backend/api/src/services/escrowFundingReconciliation.js
@@ -1,6 +1,6 @@
 import { redisClient, supabaseAdmin } from '../config/db.js';
 import logger from '../middleware/logger.js';
-import { submitEscrowRefund, getEscrowBooking } from './escrow.js';
+import { submitEscrowRefund, submitEscrowCancelWithPenalty, paisaToMaticWei, getEscrowBooking } from './escrow.js';
 import { acquireLock, renewLock, releaseLock } from '../lib/redisLock.js';
 import { sendPushNotification } from './notificationService.js';
 
@@ -60,7 +60,31 @@ async function finalizeOrRevert(order, orderRepository) {
     if (bookingFunded && !mismatchReason && order.status === 'cancelled') {
       logger.info(`[escrow-funding] Order ${order.order_display_id} is cancelled but deposit landed on-chain. Triggering refund.`);
       try {
-        await submitEscrowRefund(order.order_display_id);
+        // Issue #14687: derive the on-chain penalty from the pre-cancel trip
+        // stage persisted as `cancellation_fee` at cancel time, not from the
+        // already-cancelled `order.status` (which would always yield 0%). When
+        // a penalty applies, route through submitEscrowCancelWithPenalty so the
+        // driver is compensated instead of issuing a full refund.
+        const cancellationFee = Number(order.cancellation_fee ?? 0);
+        let driverFeeWei = 0n;
+        if (cancellationFee > 0 && order.escrow_amount_wei != null && order.total_amount) {
+          const totalAmount = Number(order.total_amount);
+          if (Number.isFinite(totalAmount) && totalAmount > 0) {
+            driverFeeWei = (BigInt(order.escrow_amount_wei) * BigInt(cancellationFee)) / BigInt(Math.round(totalAmount));
+          }
+        }
+        if (driverFeeWei === 0n) {
+          driverFeeWei = paisaToMaticWei(cancellationFee);
+        }
+
+        const submitted = driverFeeWei > 0n
+          ? await submitEscrowCancelWithPenalty(order.order_display_id, driverFeeWei)
+          : await submitEscrowRefund(order.order_display_id);
+
+        if (submitted?.error || !submitted?.txHash) {
+          throw new Error(submitted?.error || 'escrow refund was not submitted');
+        }
+
         await orderRepository.updateOrder(order.id, {
           escrow_status: 'refunded',
           escrow_refund_error: null,

--- a/backend/api/test/unit/escrowFundingReconciliation.test.js
+++ b/backend/api/test/unit/escrowFundingReconciliation.test.js
@@ -36,6 +36,8 @@ vi.mock('../../src/config/db.js', () => ({
 
 vi.mock('../../src/services/escrow.js', () => ({
   submitEscrowRefund: vi.fn(),
+  submitEscrowCancelWithPenalty: vi.fn(),
+  paisaToMaticWei: vi.fn(),
   getEscrowBooking: vi.fn(),
 }));
 


### PR DESCRIPTION
## Problem

When a customer cancels an order after the escrow deposit has already landed on-chain, the funding reconciliation worker (`escrowFundingReconciliation.js`) performed a blind full `submitEscrowRefund` for the cancelled+funded order. This ignored the cancellation penalty that was computed from the pre-cancel trip stage at cancel time, so the driver was under-penalized (0% penalty) and, for a started booking, `cancelBooking` reverts and the order was retried forever — stranding the customer's escrow.

The worker was also selecting `status`/`cancellation_fee`/`total_amount` columns that were missing from the `findStaleFundingOrders` query, so the cancelled+funded branch could never evaluate correctly (and cancelled orders were incorrectly "healed" to `funded`).

## Fix

- `escrowFundingReconciliation.js`: derive the on-chain penalty from the persisted pre-cancel `cancellation_fee` (mirroring `escrowRefundReconciliation.js`), computing `driverFeeWei` proportionally from `escrow_amount_wei`/`total_amount`. When a penalty applies, route through `submitEscrowCancelWithPenalty` (driver compensated) instead of the full `submitEscrowRefund`; otherwise keep the full refund path. Failures now record `refund_failed` instead of marking the order refunded.
- `orderRepository.js`: include `status`, `cancellation_fee`, and `total_amount` in `findStaleFundingOrders` so the penalty can be computed.
- Added the new escrow imports to the unit-test mock to keep the module importable.

## Files changed

- `backend/api/src/services/escrowFundingReconciliation.js`
- `backend/api/src/repositories/orderRepository.js`
- `backend/api/test/unit/escrowFundingReconciliation.test.js`

## Testing

- Syntax-checked the modified modules (`node --check`).
- Unit tests for `escrowFundingReconciliation` / `orderRepository` retain their existing assertions; the escrow mock was extended with `submitEscrowCancelWithPenalty` and `paisaToMaticWei` so the module imports cleanly. (Full `npm test` could not run in this environment due to a platform-specific `tslib` dependency.)

Closes #14687
