### PR TITLE
fix: remove 100 MATIC hard cap in paisaToMaticWei (#14682)

### DIFF
--- a/backend/api/src/services/escrow.js
+++ b/backend/api/src/services/escrow.js
@@ -197,7 +197,13 @@ const ESCROW_AMOUNT_TOLERANCE_WEI = 1_000_000_000n; // 1 gwei
  *
  * @param {number|string|bigint} paisa - Amount in paisa (e.g. 5000 = ₹50)
  * @returns {bigint} Amount in wei
- * @throws {RangeError} If paisa is negative, NaN, or exceeds safety cap
+ * @throws {RangeError} If paisa is negative or not a finite number
+ *
+ * NOTE: The previous 100 MATIC hard cap (MAX_ESCROW_MATIC) silently broke
+ * escrow for high-value shipments (~Rs.250,000+). The cap has been removed so
+ * large orders convert correctly; the on-chain amount is a uint256 and can
+ * represent any realistic shipment value. MAX_ESCROW_MATIC remains only as a
+ * non-blocking reference for operators/logging.
  */
 export function paisaToMaticWei(paisa) {
   if (paisa == null) {
@@ -209,11 +215,6 @@ export function paisaToMaticWei(paisa) {
   }
   const paisaBig = BigInt(Math.round(numeric));
   const maticWei = paisaBig * PAISA_WEI_SCALE;
-  const maxMaticWei = BigInt(Math.round(MAX_ESCROW_MATIC * 1e18));
-  if (maticWei > maxMaticWei) {
-    const matic = maticWei / 1_000_000_000_000_000_000n;
-    throw new RangeError(`Deposit ${matic} MATIC exceeds safety cap of ${MAX_ESCROW_MATIC} MATIC (${paisa} paisa @ ${ESCROW_MATIC_PER_PAISA} MATIC/paisa)`);
-  }
   return maticWei;
 }
 

--- a/backend/api/test/unit/escrow.test.js
+++ b/backend/api/test/unit/escrow.test.js
@@ -135,7 +135,7 @@ describe('escrow service — paisaToMaticWei', () => {
     expect(wei).toBe(400_000_000_000_000n);
   });
 
-  it('enforces the default 100 MATIC safety cap when env vars are absent', async () => {
+  it('converts large amounts without the removed 100 MATIC hard cap (env vars absent)', async () => {
     const rateEnv = process.env.ESCROW_MATIC_PER_PAISA;
     const capEnv = process.env.MAX_ESCROW_MATIC;
     delete process.env.ESCROW_MATIC_PER_PAISA;
@@ -144,17 +144,30 @@ describe('escrow service — paisaToMaticWei', () => {
     vi.resetModules();
     const { paisaToMaticWei: defaultRateWei } = await import('../../src/services/escrow.js');
 
-    // 10,000,000 paisa (₹100k) × 0.000004 = 40 MATIC — a realistic large
-    // order that is now well under the default 100 MATIC cap, no RangeError.
+    // 10,000,000 paisa (₹100k) × 0.000004 = 40 MATIC — a realistic large order.
     expect(defaultRateWei(10_000_000)).toBe(ethers.parseEther('40'));
-    // An order far beyond the cap is rejected with a handled RangeError.
-    expect(() => defaultRateWei(100_000_000_000)).toThrow(RangeError);
+
+    // Previously the 100 MATIC cap (~Rs.250,000) made this throw a RangeError,
+    // silently breaking escrow for high-value shipments. The cap is removed so
+    // large/high-value orders convert correctly instead of throwing.
+    const bigPaisa = 100_000_000_000; // ₹1B @ default rate = 400,000 MATIC
+    expect(() => defaultRateWei(bigPaisa)).not.toThrow();
+    expect(defaultRateWei(bigPaisa)).toBe(BigInt(bigPaisa) * 4_000_000_000_000n);
 
     if (rateEnv !== undefined) process.env.ESCROW_MATIC_PER_PAISA = rateEnv;
     else delete process.env.ESCROW_MATIC_PER_PAISA;
     if (capEnv !== undefined) process.env.MAX_ESCROW_MATIC = capEnv;
     else delete process.env.MAX_ESCROW_MATIC;
     vi.resetModules();
+  });
+
+  it('converts a high-value shipment above the old 100 MATIC cap (issue #14682)', () => {
+    // 62,500,000 paisa (₹625,000) × 0.000004 = 250 MATIC — above the old cap
+    // that broke escrow for shipments above ~Rs.250,000.
+    const paisa = 62_500_000;
+    const wei = paisaToMaticWei(paisa);
+    expect(wei).toBe(ethers.parseEther('250'));
+    expect(wei).toBe(BigInt(paisa) * 4_000_000_000_000n);
   });
 
   it('converts using a custom rate when env var is overridden', async () => {


### PR DESCRIPTION
## Problem

`paisaToMaticWei` (`backend/api/src/services/escrow.js`) enforced a `MAX_ESCROW_MATIC` hard cap of 100 MATIC. At the configured `ESCROW_MATIC_PER_PAISA` rate (~0.000004 MATIC/paisa), that is only ~Rs.250,000. When a bid exceeded the cap, the function threw a `RangeError` deep inside `bidAcceptanceService.acceptBid` (which calls it to set `escrow_amount_wei`), silently breaking escrow for large/high-value shipments. If the client instead capped the deposit, the on-chain amount no longer matched `escrow_amount_wei` and the deposit was rejected with `DEPOSIT_AMOUNT_MISMATCH`.

## Fix

- Removed the `MAX_ESCROW_MATIC` enforcement (the `RangeError` throw) from `paisaToMaticWei`. The on-chain escrow amount is a `uint256` and can represent any realistic shipment value, so the cap is unnecessary and harmful.
- Preserved the legitimate input validation: `paisaToMaticWei` still throws `TypeError`/`RangeError` for `null`/negative/non-finite inputs (existing behavior/tests retained).
- `MAX_ESCROW_MATIC` is kept as a non-blocking operator/logging reference only; it no longer blocks conversions.
- Added unit tests covering a high-value shipment above the old cap (62,500,000 paisa → 250 MATIC) and confirming very large amounts no longer throw.

## Files changed

- `backend/api/src/services/escrow.js` — removed the hard cap branch in `paisaToMaticWei`.
- `backend/api/test/unit/escrow.test.js` — updated/replaced the cap test and added coverage for amounts above the old cap.

## Testing

- `backend/api/test/unit/escrow.test.js` updated: new tests assert large and high-value amounts convert correctly without throwing (previously they threw `RangeError`). Existing negative/NaN/Infinity validation tests remain unchanged.
- Note: full suite execution was not possible in this environment due to an upstream platform-specific (`openharmony`) dependency conflict; the change is minimal and verified by inspection/test updates.

Closes #14682
