### PR TITLE
fix(cbTranslator): fix apostrophe-terminated Punjabi string

### DIFF
--- a/backend/api/src/services/cbTranslator.js
+++ b/backend/api/src/services/cbTranslator.js
@@ -20,7 +20,7 @@ const COMMON_DISPATCH_TRANSLATIONS = {
         'turn off engine during loading': 'Apague el motor durante la carga'
     },
     'pa': {
-        'proceed to dock door 14': 'ਡੌਕ ਡੋਰ 14 'ਤੇ ਜਾਓ',
+        'proceed to dock door 14': "ਡੌਕ ਡੋਰ 14 'ਤੇ ਜਾਓ",
         'caution icy bridge ahead': 'ਅੱਗੇ ਬਰਫ਼ੀਲੇ ਪੁਲ ਤੋਂ ਸਾਵਧਾਨ ਰਹੋ',
         'turn off engine during loading': 'ਲੋਡਿੰਗ ਦੌਰਾਨ ਇੰਜਣ ਬੰਦ ਕਰੋ'
     }
@@ -47,7 +47,7 @@ export function translateVoiceTransmission(transmissionParams) {
     const normalizedText = transcriptText.trim().toLowerCase();
     const tgtLangLower = tgtLangKey.toLowerCase();
 
-    let translatedText = transcriptText;
+    let translatedText;
 
     // Perform translation lookup or fallback to synthesized translation engine
     if (COMMON_DISPATCH_TRANSLATIONS[tgtLangLower] && COMMON_DISPATCH_TRANSLATIONS[tgtLangLower][normalizedText]) {


### PR DESCRIPTION
Closes #14882

## Problem

`backend/api/src/services/cbTranslator.js` line 23: the Punjabi translation `'ਡੌਕ ਡੋਰ 14 'ਤੇ ਜਾਓ'` contains an apostrophe that terminates the single-quoted string early, leaving `ਤੇ ਜਾਓ'` as garbage → `Parsing error: Unexpected token ਤੇ`. The module cannot be loaded.

## Fix

- Use double quotes so the apostrophe is literal: `"ਡੌਕ ਡੋਰ 14 'ਤੇ ਜਾਓ"`.
- Also drop the redundant initial `translatedText = transcriptText` assignment (it is overwritten in both branches — `no-useless-assignment` surfaced once the parse error was fixed).

Verified with `node --check` and ESLint (0 errors) on the module.
