### PR TITLE
fix(voiceService): restore mock intent pipeline and fix message fallbacks

### DIFF
--- a/backend/api/src/services/voiceService.js
+++ b/backend/api/src/services/voiceService.js
@@ -76,7 +76,31 @@ async function getBookingContext(bookingId, userId) {
   return null;
 }
 
-export async function processVoiceQuery(userId, bookingId, audioBuffer, filename) {
+function detectQueryIntent(transcript) {
+  const text = (transcript || '').toLowerCase();
+  if (text.includes('payment') || text.includes('release') || text.includes('paid')) {
+    return 'payment_status';
+  }
+  if (text.includes('arrive') || text.includes('arrival') || text.includes('eta') || text.includes('when')) {
+    return 'eta';
+  }
+  return 'package_status';
+}
+
+function buildResponseForIntent(intent, bookingData, transcript) {
+  const orderRef = bookingData?.order_display_id || bookingData?.id || 'your order';
+  const status = bookingData?.status || bookingData?.current_status || 'in transit';
+  switch (intent) {
+    case 'payment_status':
+      return `Your payment for ${orderRef} is ${bookingData?.escrow_status || 'processing'}.`;
+    case 'eta':
+      return `Your shipment for ${orderRef} is ${status} and is on schedule.`;
+    default:
+      return `Your shipment ${orderRef} is currently ${status}.`;
+  }
+}
+
+export async function processVoiceQuery(userId, bookingId, audioBuffer, filename, textQuery = null) {
   const bookingData = await getBookingContext(bookingId, userId);
   
   if (!process.env.OPENAI_API_KEY || !process.env.ELEVENLABS_API_KEY) {
@@ -131,7 +155,7 @@ export async function processVoiceQuery(userId, bookingId, audioBuffer, filename
     transcript = whisperResponse.data.text;
   } catch (err) {
     logger.error('Whisper transcription failed:', err?.message ?? String(err));
-    throw new Error('Transcription failed: ' + err?.message ?? String(err), { cause: err });
+    throw new Error('Transcription failed: ' + (err?.message ?? String(err)), { cause: err });
   }
 
   const intent = detectQueryIntent(transcript);
@@ -157,7 +181,7 @@ export async function processVoiceQuery(userId, bookingId, audioBuffer, filename
     responseText = llmResponse.data.choices[0].message.content;
   } catch (err) {
     logger.error('LLM completion failed:', err?.message ?? String(err));
-    throw new Error('LLM failed: ' + err?.message ?? String(err), { cause: err });
+    throw new Error('LLM failed: ' + (err?.message ?? String(err)), { cause: err });
   }
 
   // Production ElevenLabs TTS call
@@ -185,7 +209,7 @@ export async function processVoiceQuery(userId, bookingId, audioBuffer, filename
     audioUrl = `/api/voice/audio/${audioId}`;
   } catch (err) {
     logger.error('ElevenLabs TTS failed:', err?.message ?? String(err));
-    throw new Error('TTS failed: ' + err?.message ?? String(err), { cause: err });
+    throw new Error('TTS failed: ' + (err?.message ?? String(err)), { cause: err });
   }
 
   return {


### PR DESCRIPTION
Closes #14886

## Problem

`backend/api/src/services/voiceService.js` has two clusters of breakage:

1. **Mock intent pipeline references undefined helpers (5× ESLint `no-undef`)**: when `OPENAI_API_KEY`/`ELEVENLABS_API_KEY` are absent, `processVoiceQuery` uses `textQuery` (never declared) and calls `detectQueryIntent(...)` / `buildResponseForIntent(...)` — neither exists → `ReferenceError`.
2. **Message-error precedence bug (3× `no-constant-binary-expression`)**: `'Transcription failed: ' + err?.message ?? String(err)` — `??` binds the whole concatenation (never nullish), so `String(err)` never runs and the message is always `"Transcription failed: undefined"`.

## Fix

- Declare `textQuery = null` as an optional parameter (backward compatible — the mock path already falls back to audio-buffer sampling when it is falsy).
- Implement the two missing mock helpers: `detectQueryIntent` (keyword-based: payment/ETA/package-status) and `buildResponseForIntent` (canned responses from `bookingData`).
- Parenthesize the fallbacks in all three error throws: `'... ' + (err?.message ?? String(err))`.

Verified with `node --check` and ESLint (0 errors) on the module.
