### PR TITLE
fix: apply ownership in requirePolicy when getResource omitted (#14690)

### DIFF
--- a/backend/api/src/middleware/requirePolicy.js
+++ b/backend/api/src/middleware/requirePolicy.js
@@ -25,6 +25,12 @@ import { policy, PolicyError } from '../security/policyEngine.js';
  *   resource from req. Called as `getResource(req)` and its return value is
  *   passed to the ownership check. When omitted, the ownership check is
  *   skipped (backward-compatible with existing call sites).
+ *
+ * A policy that is gated by ownership *alone* (no role restriction) cannot be
+ * evaluated without a resource, so omitting `getResource` for such a policy is
+ * a misconfiguration. Instead of silently skipping the check (latent IDOR) or
+ * always denying (broken endpoint), the middleware fails closed with a clear
+ * 500 so the misconfiguration is caught during development.
  */
 export function requirePolicy(action, getResource) {
   return (req, res, next) => {
@@ -33,6 +39,12 @@ export function requirePolicy(action, getResource) {
     }
 
     const requestId = req.requestId || req.id;
+
+    if (policy.isOwnershipOnlyPolicy(action) && !getResource) {
+      const message = `Misconfigured policy '${action}': ownership-only policies require a getResource resolver.`;
+      console.error(`[requirePolicy] ${message}`);
+      return res.status(500).json({ error: message });
+    }
 
     if (getResource) {
       Promise.resolve(getResource(req)).then((resource) => {

--- a/backend/api/src/routes/orderRoutes.js
+++ b/backend/api/src/routes/orderRoutes.js
@@ -748,7 +748,10 @@ router.post('/predict-demand', authenticate, userLimiter, requireRole(['customer
  *             schema:
  *               $ref: '#/components/schemas/DriverLocationResponse'
  */
-router.get('/:id/driver-location', authenticate, userLimiter, telemetryLimiter, requirePolicy('order:view-driver-location'), validateParams(paramIdSchema), async (req, res) => {
+router.get('/:id/driver-location', authenticate, userLimiter, telemetryLimiter, requirePolicy('order:view-driver-location', async (req) => {
+  const order = await orderValidationService.findOrderByIdOrDisplayId(req.params.id, 'id, customer_id, driver_id, status');
+  return { order };
+}), validateParams(paramIdSchema), async (req, res) => {
   const orderId = req.params.id;
   try {
     const order = await orderValidationService.findOrderByIdOrDisplayId(orderId, 'id, customer_id, driver_id, status');

--- a/backend/api/src/security/policyEngine.js
+++ b/backend/api/src/security/policyEngine.js
@@ -219,6 +219,18 @@ export class PolicyEngine {
   }
 
   /**
+   * Returns true when the named action is gated by ownership alone (no role
+   * restriction). Such policies MUST be given a resolved resource, otherwise
+   * the ownership predicate cannot be evaluated.
+   * @param {string} action
+   * @returns {boolean}
+   */
+  isOwnershipOnlyPolicy(action) {
+    const def = POLICIES[action];
+    return !!(def && typeof def.ownership === 'function' && (!def.roles || def.roles.length === 0));
+  }
+
+  /**
    * Returns a snapshot of all policies for admin introspection.
    * @returns {object}
    */

--- a/backend/api/test/unit/orderRoutesDriverLocationSyntax.test.js
+++ b/backend/api/test/unit/orderRoutesDriverLocationSyntax.test.js
@@ -66,7 +66,7 @@ describe('orderRoutes.js driver-location route syntax (issue #6662)', () => {
     const { call } = driverLocationCall(source);
 
     for (const piece of [
-      "requirePolicy('order:view-driver-location')",
+      "requirePolicy('order:view-driver-location'",
       'validateParams(paramIdSchema)',
       "async (req, res) =>",
     ]) {


### PR DESCRIPTION
## Problem

`requirePolicy(action, getResource)` (`backend/api/src/middleware/requirePolicy.js`) only evaluated the ownership check when a `getResource` resolver was supplied. For an **ownership-only** policy — one gated by ownership with no role restriction, such as `order:view-driver-location` — omitting `getResource` meant the ownership predicate received an `undefined` resource, so the policy could never be satisfied. The endpoint `GET /api/orders/:id/driver-location` was registered as `requirePolicy('order:view-driver-location')` with no resolver, making it **always return 403** (a self-DoS / broken access control in reverse). The same latent failure applied to any ownership-only policy wired without a resolver.

## Fix

- `backend/api/src/security/policyEngine.js`: added `isOwnershipOnlyPolicy(action)` to detect policies gated by ownership alone.
- `backend/api/src/middleware/requirePolicy.js`: when an ownership-only policy is used without a `getResource` resolver, the middleware now fails closed with a clear `500` "misconfigured policy" error (logged) instead of silently skipping the ownership check or always denying. Role-gated policies keep their backward-compatible behavior.
- `backend/api/src/routes/orderRoutes.js`: the `GET /:id/driver-location` route now passes a `getResource` that loads the order by `req.params.id`, so legitimate owners (customer, driver, or admin) are correctly authorized and the handler runs.

## Files changed

- `backend/api/src/security/policyEngine.js`
- `backend/api/src/middleware/requirePolicy.js`
- `backend/api/src/routes/orderRoutes.js`
- `backend/api/test/unit/orderRoutesDriverLocationSyntax.test.js` (updated assertion for the new route signature)

## Testing

- `node --check` syntax gate on `orderRoutes.js` remains valid (the driver-location route is still a single balanced `router.get` call with one async handler).
- Existing `requirePolicy` unit test (`requirePolicy.test.js`) still passes: unknown/role-only actions without a resolver continue to call `next()`.
- Ownership-only policies lacking a resolver now return `500` (clear misconfiguration) rather than `403`.
- `GET /api/orders/:id/driver-location` now resolves the order and authorizes owners via the ownership predicate instead of always denying.

Closes #14690
