### PR TITLE
fix: credit driver on PaymentReleased and fix reconcileWalletLedger (#14685)

### DIFF
--- a/backend/api/src/services/webhook/escrowWebhookProcessor.js
+++ b/backend/api/src/services/webhook/escrowWebhookProcessor.js
@@ -21,7 +21,7 @@ async function findOrderByIdOrDisplayId(orderId) {
   if (!orderId) {
     throw new Error('Missing orderId in escrow webhook payload');
   }
-  const columns = 'id, order_display_id, driver_id, escrow_status, release_tx_hash, refund_tx_hash, escrow_amount_wei, escrow_booking_id';
+  const columns = 'id, order_display_id, driver_id, escrow_status, release_tx_hash, refund_tx_hash, escrow_amount_wei, escrow_booking_id, bid_amount, total_amount';
 
   if (UUID_REGEX.test(orderId)) {
     const { data, error } = await db
@@ -68,10 +68,33 @@ async function reconcileWalletLedger(order, txHash) {
     throw new Error(`Failed to reconcile wallet ledger for ${order.order_display_id}: ${error.message}`);
   }
 
-  if (!data || data.length === 0) {
+  // The authoritative finalize (`complete_trip_tx`, invoked by `creditDriverWallet`
+  // and by the reconciliation worker) inserts the credit directly as 'confirmed',
+  // so there is often no 'pending' credit row to reconcile. Do NOT treat a missing
+  // pending credit as an error — the driver payout is already confirmed. Only a
+  // genuine DB failure above should surface (issue #14685).
+  return;
+}
+
+// Authoritative driver payout for a verified on-chain release. Runs
+// `complete_trip_tx` (service_role, no OTP) which is idempotent on
+// `status = 'payment_released'`: it increments `driver_details.wallet_confirmed`
+// / `wallet_total` and inserts the confirmed `wallet_transactions` credit row
+// exactly once. The webhook has already verified the Polygon release receipt, so
+// the supplied release hash is trustworthy (issue #14685).
+async function creditDriverWallet(order, txHash) {
+  if (!order.driver_id) {
+    return;
+  }
+  const { error } = await requireDb().rpc('complete_trip_tx', {
+    p_order_id: order.id,
+    p_otp_id: null,
+    p_release_tx_hash: txHash || null,
+  });
+
+  if (error) {
     throw new Error(
-      `Wallet ledger reconciliation matched no credit transaction for order ${order.order_display_id} ` +
-        `(driver ${order.driver_id}) — driver payout may be unconfirmed`
+      `Failed to finalize trip and credit driver wallet for ${order.order_display_id}: ${error.message}`
     );
   }
 }
@@ -172,6 +195,7 @@ async function handlePaymentReleased(payload) {
   // the (idempotent) wallet ledger so a crash between the order update and the
   // wallet update is healed, then short-circuit without re-applying effects.
   if (order.escrow_status === 'released') {
+    await creditDriverWallet(order, payload.txHash || order.release_tx_hash);
     await reconcileWalletLedger(order, payload.txHash || order.release_tx_hash);
     logger.info(`[Webhook] Order ${order.order_display_id} already released — duplicate delivery ignored.`);
     return;
@@ -201,6 +225,7 @@ async function handlePaymentReleased(payload) {
     );
   }
 
+  await creditDriverWallet(order, payload.txHash);
   await reconcileWalletLedger(order, payload.txHash);
   logger.info(`[Webhook] Order ${order.order_display_id} marked escrow released (tx: ${payload.txHash})`);
 }
@@ -264,6 +289,7 @@ async function handleWithdrawalSettled(payload) {
       }
     }
     if (!isRefund) {
+      await creditDriverWallet(order, txHash);
       await reconcileWalletLedger(order, txHash);
     }
     logger.info(`[Webhook] Order ${order.order_display_id} already ${targetStatus} — duplicate delivery ignored.`);
@@ -301,6 +327,7 @@ async function handleWithdrawalSettled(payload) {
   }
 
   if (!isRefund) {
+    await creditDriverWallet(order, txHash);
     await reconcileWalletLedger(order, txHash);
   }
 

--- a/backend/api/test/unit/escrowWebhookGuards.test.js
+++ b/backend/api/test/unit/escrowWebhookGuards.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const { dbMock } = vi.hoisted(() => ({
-  dbMock: { supabaseAdmin: { from: vi.fn() } },
+  dbMock: { supabaseAdmin: { from: vi.fn(), rpc: vi.fn().mockResolvedValue({ data: null, error: null }) } },
 }));
 
 vi.mock('../../src/config/db.js', () => ({

--- a/backend/api/test/unit/escrowWebhookProcessor.test.js
+++ b/backend/api/test/unit/escrowWebhookProcessor.test.js
@@ -29,6 +29,7 @@ const mockQuery = {
 
 const mockSupabaseAdmin = {
   from: vi.fn(() => mockQuery),
+  rpc: vi.fn().mockResolvedValue({ data: null, error: null }),
 };
 
 vi.mock('../../src/config/db.js', () => ({


### PR DESCRIPTION
## Problem

The `PaymentReleased` webhook handler (`handlePaymentReleased` in `backend/api/src/services/webhook/escrowWebhookProcessor.js`) flipped `orders.escrow_status` to `'released'` but never credited the driver. The only code path that increments `driver_details.wallet_confirmed` and inserts the credit `wallet_transactions` row is the `complete_trip_tx` RPC, which the webhook never called.

Instead the webhook relied on `reconcileWalletLedger`, which only `UPDATE`s an **existing `'pending'`** credit row. But `complete_trip_tx` inserts the credit as `'confirmed'`, so there is never a `'pending'` row to reconcile. `reconcileWalletLedger` therefore always threw `"matched no credit transaction"`, causing the webhook to error on its first (pre-finalization) fire and leaving the driver unpaid if the `escrowReleaseReconciliation` worker was unavailable.

## Fix

- Added `creditDriverWallet(order, txHash)`, which invokes the authoritative finalize `complete_trip_tx` (service_role, no OTP). `complete_trip_tx` is idempotent on `status = 'payment_released'`, so it credits `driver_details.wallet_confirmed`/`wallet_total` and inserts the confirmed `wallet_transactions` credit row exactly once. It is now called from `handlePaymentReleased` (both the primary and duplicate-delivery paths) and from `handleWithdrawalSettled`.
- Fixed `reconcileWalletLedger` so it no longer throws when no `'pending'` credit exists — the payout was already confirmed by `complete_trip_tx`. It now treats a missing `'pending'` credit as a successful idempotent no-op (only a genuine DB failure surfaces). This removes the constant webhook failure noise and the window where `escrow_status='released'` but the driver was unpaid.

## Files changed

- `backend/api/src/services/webhook/escrowWebhookProcessor.js` — added `creditDriverWallet` (calls `complete_trip_tx`) and integrated it into `handlePaymentReleased` / `handleWithdrawalSettled`; `reconcileWalletLedger` no longer throws on an already-confirmed credit.
- `backend/api/test/unit/escrowWebhookProcessor.test.js` — added `rpc` mock so the new `complete_trip_tx` call is exercised.
- `backend/api/test/unit/escrowWebhookGuards.test.js` — added `rpc` mock for robustness.

## Testing

- Added a `rpc` mock returning `{ data: null, error: null }` to the unit tests so `creditDriverWallet` is exercised without a live DB; `complete_trip_tx` is idempotent and fail-closed via its existing SQL guards.
- Existing webhook unit tests (order released + wallet ledger reconcile, idempotent duplicate delivery, no per-driver multiplication) continue to pass with the new flow.
- Manual verification: a `PaymentReleased` event now marks the order released, runs `complete_trip_tx` to credit the driver exactly once, and `reconcileWalletLedger` is a no-op when the credit is already `'confirmed'`.

Closes #14685
