### PR TITLE
fix(svc): size decompressFloatMatrix buffer in floats, not bytes (#14677)

### DIFF
--- a/services/compress-avx512/src/zstd_simd.cpp
+++ b/services/compress-avx512/src/zstd_simd.cpp
@@ -69,15 +69,18 @@ std::vector<float> Avx512MatrixCompressor::decompressFloatMatrix(
         return {};
     }
 
-    std::vector<float> restored(decompCap / sizeof(float));
+    std::vector<uint8_t> restoredBytes(decompCap);
     size_t written = ZSTD_decompress(
-        restored.data(), decompCap, compressed.data(), compressed.size()
+        restoredBytes.data(), decompCap, compressed.data(), compressed.size()
     );
-    if (ZSTD_isError(written)) {
+    if (ZSTD_isError(written) || written % sizeof(float) != 0) {
         return {};
     }
 
-    restored.resize(written / sizeof(float));
+    std::vector<float> restored(
+        reinterpret_cast<float*>(restoredBytes.data()),
+        reinterpret_cast<float*>(restoredBytes.data() + written)
+    );
     return restored;
 #else
     size_t count = compressed.size() / sizeof(float);


### PR DESCRIPTION
## Problem

In `services/compress-avx512/src/zstd_simd.cpp`, `decompressFloatMatrix` allocates the destination buffer as `std::vector<float>(decompCap / sizeof(float))` (floats) but hands ZSTD a `dstCapacity` of `decompCap` **bytes**. Because `decompCap / sizeof(float)` floors the byte count, the allocation is up to 3 bytes smaller than the capacity ZSTD writes into, producing a heap buffer overflow / memory corruption on attacker-supplied frames whose advertised content size is not a multiple of 4 (and a large `decompCap` triggers OOM). The decompressed byte count was also never validated to be a multiple of `sizeof(float)` before reinterpretation.

## Fix

Allocate the destination buffer in **bytes** (`std::vector<uint8_t>(decompCap)`), decompress into it, and validate both the ZSTD error and that `written % sizeof(float) == 0` before reinterpreting the bytes as `float`. This guarantees the buffer is always large enough for the bytes ZSTD writes and that the reinterpretation is aligned/whole.

## Files changed

- `services/compress-avx512/src/zstd_simd.cpp` — `decompressFloatMatrix`: byte-sized destination buffer + post-decompress validation.

## Testing

- Review of the ZSTD API contract (`ZSTD_decompress` writes `dstCapacity` bytes; `ZSTD_getFrameContentSize` returns bytes).
- Manual reasoning: for `decompCap = 4k`, allocation is exactly `4k` bytes and `written % 4 == 0` holds; for `decompCap % 4 != 0` the validation now rejects instead of overrunning.
- Existing build/structure preserved; non-HAVE_ZSTD path unchanged.

Closes #14677
