### PR TITLE
fix(tracker): declare messageRateTrackerCleanupInterval and import GpsLog model

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -6,6 +6,7 @@ import crypto from 'crypto';
 import { ebpfLoader } from '../../../../ebpf/loader.js';
 import { createLocationEventBus } from './locationEventBus.js';
 import telemetryBuffer from './telemetryBuffer.js';
+import GpsLog from '../models/GpsLog.js';
 
 const TELEMETRY_SCHEMA = {
   lat: { type: 'number', required: false, min: -90, max: 90 },
@@ -178,6 +179,7 @@ let wsHeartbeatInterval = null;
 let telemetryMonitorInterval = null;
 let driverStateSweepInterval = null;
 let wsUpgradeLimitsCleanupInterval = null;
+let messageRateTrackerCleanupInterval = null;
 const HEARTBEAT_INTERVAL_MS = parseInt(process.env.WS_HEARTBEAT_INTERVAL_MS, 10) || 180000; // 3 minutes
 
 const WS_UPGRADE_RATE_LIMIT = 5;


### PR DESCRIPTION
Closes #14887

## Problem

`backend/api/src/sockets/tracker.js` uses two never-declared identifiers (ESLint `no-undef`):

1. `messageRateTrackerCleanupInterval` — used at lines 713-721 (`clearInterval` + `setInterval`) but never declared, unlike its sibling `wsUpgradeLimitsCleanupInterval` at line 180 → `ReferenceError` when a WebSocket server is created.
2. `GpsLog` — `await GpsLog.create(doc)` at lines 869/919, never imported (model exists at `backend/api/src/models/GpsLog.js`) → `ReferenceError` when persisting a GPS log.

## Fix

- Declare `let messageRateTrackerCleanupInterval = null;` next to `let wsUpgradeLimitsCleanupInterval = null;`.
- Add `import GpsLog from '../models/GpsLog.js';`.

Verified with `node --check` and ESLint.
