### PR TITLE
build: resolve merge-conflict markers in TruxifyUpgradeable.sol and zkEVM.sol (#14675)

### DIFF
--- a/blockchain/contracts/TruxifyUpgradeable.sol
+++ b/blockchain/contracts/TruxifyUpgradeable.sol
@@ -123,10 +123,8 @@ contract TruxifyUpgradeable is
     event EscrowCreated(uint256 indexed escrowId, address customer, address driver, uint256 amount);
     event EscrowReleased(uint256 indexed escrowId, address driver, uint256 amount);
     event EscrowDisputed(uint256 indexed escrowId, address customer);
-<<<<<<< HEAD
-=======
+
     event EscrowResolved(uint256 indexed escrowId, address recipient, uint256 amount);
->>>>>>> upstream/main
     event ProposalCreated(uint256 indexed proposalId, address proposer, address implementation);
     event VoteCast(uint256 indexed proposalId, address voter, bool support, uint256 weight);
     event ProposalExecuted(uint256 indexed proposalId, bool passed);
@@ -232,13 +230,10 @@ contract TruxifyUpgradeable is
         uint256 requestTimestamp = emergencyUpgradeRequests[newImplementation];
         if (requestTimestamp != 0) {
             require(
-<<<<<<< HEAD
-=======
                 approvedImplementations[newImplementation],
                 "Implementation not approved"
             );
             require(
->>>>>>> upstream/main
                 block.timestamp >= requestTimestamp + EMERGENCY_UPGRADE_TIMELOCK,
                 "Emergency timelock not yet elapsed"
             );
@@ -316,8 +311,6 @@ function disputeEscrow(uint256 escrowId) external onlyRole(DEFAULT_ADMIN_ROLE) n
     emit EscrowDisputed(escrowId, msg.sender);
 }
 
-<<<<<<< HEAD
-=======
 /**
  * @dev Resolves a disputed escrow by releasing the funds to either the
  *      customer (refund) or the driver, as determined by the dispute
@@ -342,7 +335,6 @@ function resolveDisputedEscrow(uint256 escrowId, address recipient) external onl
     emit EscrowResolved(escrowId, recipient, escrow.amount);
 }
 
->>>>>>> upstream/main
     // ============ DAO Governance ============
     function createProposal(
         address newImplementation,
@@ -504,13 +496,10 @@ function resolveDisputedEscrow(uint256 escrowId, address recipient) external onl
         require(newImplementation != address(0), "Invalid implementation");
         require(bytes(reason).length > 0, "Reason required");
         require(
-<<<<<<< HEAD
-=======
             approvedImplementations[newImplementation],
             "Implementation not approved"
         );
         require(
->>>>>>> upstream/main
             emergencyUpgradeRequests[newImplementation] == 0,
             "Emergency upgrade already requested for this implementation"
         );

--- a/blockchain/contracts/zkEVM.sol
+++ b/blockchain/contracts/zkEVM.sol
@@ -131,16 +131,10 @@ contract zkEVM is Ownable, ReentrancyGuard, Pausable {
             require(_verifySignature(txHashForSig, signature, from), "Invalid signature");
 
             processedTxHashes[txHash] = true;
-<<<<<<< HEAD
-            usedNonces[from][nonce] = true;
-
-            // Same per-tx signature/nonce/balance checks as the single-tx path.
-=======
 
             // Same per-tx signature/nonce/balance checks as the single-tx path.
             // _applyTx marks the nonce used; do not mark it before the call or
             // _applyTx's own "Nonce already used" check reverts every batch.
->>>>>>> upstream/main
             _applyTx(from, to, value, data, nonce, gasPrice, gasLimit, signature);
             txHashes[i] = txHash;
         }
@@ -322,14 +316,11 @@ contract zkEVM is Ownable, ReentrancyGuard, Pausable {
     }
 
     function _verifyProof(bytes calldata proof) internal view returns (bool) {
-<<<<<<< HEAD
-=======
         // A real Groth16/STARK verifier must be configured before withdrawals
         // or batch execution can ever succeed. Reverting here (instead of
         // silently failing on the placeholder) makes misconfigurations loud so
         // user funds are never stranded by an unconfigured proof check.
         require(verifier != address(0), "zkEVM: verifier not configured");
->>>>>>> upstream/main
         require(proof.length > 0, "Empty proof");
         (uint[2] memory a, uint[2][2] memory b, uint[2] memory c, uint[2] memory input) =
             abi.decode(proof, (uint[2], uint[2][2], uint[2], uint[2]));


### PR DESCRIPTION
## Problem

Unresolved git merge-conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) remained in `TruxifyUpgradeable.sol` and `zkEVM.sol` after a merge, causing the Solidity compiler to fail and breaking the build. The markers spanned four sections in `TruxifyUpgradeable.sol` (an `EscrowResolved` event, an `approvedImplementations` guard in the emergency-upgrade path, a `resolveDisputedEscrow` function, and another `approvedImplementations` guard in the emergency-upgrade request) and two sections in `zkEVM.sol` (a duplicate/batch nonce-marking block and a `verifier != address(0)` guard in `_verifyProof`).

## Fix

Removed all conflict markers from both files, keeping the correct (`upstream/main`) code in each case:
- TruxifyUpgradeable.sol: added the `EscrowResolved` event, the `resolveDisputedEscrow` function, and the `approvedImplementations` approval checks; dropped the duplicate nonce marking that would have collided with `_applyTx`'s own guard.
- zkEVM.sol: kept the comment/guard that avoids double-marking nonces before `_applyTx`, and kept the `verifier not configured` check in `_verifyProof`.

No logic beyond the conflict resolution was changed.

## Files changed

- `blockchain/contracts/TruxifyUpgradeable.sol`
- `blockchain/contracts/zkEVM.sol`

## Testing

- Verified no remaining conflict markers via `Select-String` for `<<<<<<<` / `=======` / `>>>>>>>`.
- Compilation/CI should now proceed (previously failed due to parser errors from the markers).

Closes #14675
