### PR TITLE
fix(svc): reject forged range proofs in zkp-verifier-rust (#14678)

### DIFF
--- a/services/zkp-verifier-rust/src/bulletproofs.rs
+++ b/services/zkp-verifier-rust/src/bulletproofs.rs
@@ -1,3 +1,4 @@
+use ed25519_dalek::{Signer, SigningKey, VerifyingKey};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -12,27 +13,58 @@ pub struct BulletproofResult {
     pub is_in_range: bool,
     pub proof_bytes_hex: String,
     pub commitment_hex: String,
+    /// Ed25519 signature (hex) over the canonical range-claim payload, produced
+    /// by the weighing device's secret key. A prover that does not hold the
+    /// device key cannot forge a valid signature, so a self-asserted weight is
+    /// rejected even when the encoded weight is within the limit.
+    pub signature_hex: String,
+}
+
+/// Canonically encodes the weight claim (committed weight + blinding factor) so
+/// the signed commitment is unambiguous. The verifier reconstructs exactly
+/// these bytes and verifies the device signature over them.
+fn canonical_range_payload(weight: u64, blinding: &[u8]) -> Vec<u8> {
+    let mut out = Vec::new();
+    out.extend_from_slice(b"truxify.zkp.range.v1");
+    out.extend_from_slice(&weight.to_be_bytes());
+    out.extend_from_slice(&(blinding.len() as u64).to_be_bytes());
+    out.extend_from_slice(blinding);
+    out
 }
 
 pub struct BulletproofsGenerator;
 
 impl BulletproofsGenerator {
-    pub fn prove_weight_range(input: &BulletproofInput) -> BulletproofResult {
+    /// Produces a range proof that is cryptographically bound to the device's
+    /// Ed25519 secret key. Only the weighing device holds this key, so an
+    /// attacker reading the (public) verifier binary cannot fabricate a proof.
+    pub fn prove_weight_range(input: &BulletproofInput, signing_key: &SigningKey) -> BulletproofResult {
         let is_in_range = input.weight_kg <= input.max_limit_kg;
         let commitment = format!("0xcomm_{:x}_{}", input.weight_kg, input.blinding_factor);
         let proof = format!("0xbproof_{:x}_{}", input.weight_kg, hex::encode(&input.blinding_factor));
+
+        let payload = canonical_range_payload(input.weight_kg, input.blinding_factor.as_bytes());
+        let signature = signing_key.sign(&payload);
 
         BulletproofResult {
             is_in_range,
             proof_bytes_hex: proof,
             commitment_hex: commitment,
+            signature_hex: hex::encode(signature.to_bytes()),
         }
     }
 
-    pub fn verify_range_proof(result: &BulletproofResult, max_allowed: u64) -> bool {
+    /// Verifies a range proof. SECURITY: the claimed weight is never trusted on
+    /// its own -- it is only accepted when it is bound to a valid Ed25519
+    /// signature from the device key over the exact (weight, blinding) the proof
+    /// encodes. A prover that invents an arbitrary in-range weight cannot
+    /// produce a valid signature, so the forged proof is rejected.
+    pub fn verify_range_proof(
+        result: &BulletproofResult,
+        max_allowed: u64,
+        verifying_key: &VerifyingKey,
+    ) -> bool {
         // SECURITY: never trust the prover-supplied `is_in_range` flag.
-        // Recompute the claimed weight and blinding from the proof and commitment,
-        // confirm they are mutually consistent, then derive `in_range` ourselves.
 
         // Expected formats:
         //   proof_bytes_hex = "0xbproof_{weight_hex}_{blinding_hex}"
@@ -67,6 +99,24 @@ impl BulletproofsGenerator {
             Err(_) => return false,
         };
         if proof_blinding != commit_parts[2].as_bytes() {
+            return false;
+        }
+
+        // Cryptographic binding: the claimed (weight, blinding) must be covered
+        // by a valid signature from the device key. Without this, a prover could
+        // simply encode any in-range weight and pass the check below.
+        let payload = canonical_range_payload(proof_weight, &proof_blinding);
+        let sig_bytes = match hex::decode(&result.signature_hex) {
+            Ok(b) => match <[u8; 64]>::try_from(b.as_slice()) {
+                Ok(arr) => arr,
+                Err(_) => return false,
+            },
+            Err(_) => return false,
+        };
+        if verifying_key
+            .verify_strict(&payload, &ed25519_dalek::Signature::from_bytes(&sig_bytes))
+            .is_err()
+        {
             return false;
         }
 

--- a/services/zkp-verifier-rust/src/lib.rs
+++ b/services/zkp-verifier-rust/src/lib.rs
@@ -1,4 +1,3 @@
 pub mod bulletproofs;
-pub mod bulletproofs;
 pub mod verifier;
 pub mod weight_proof;

--- a/services/zkp-verifier-rust/tests/bulletproof_test.rs
+++ b/services/zkp-verifier-rust/tests/bulletproof_test.rs
@@ -1,54 +1,149 @@
+use ed25519_dalek::{Signer, SigningKey, VerifyingKey};
+use truxify_zkp_verifier::bulletproofs::{
+    BulletproofInput, BulletproofResult, BulletproofsGenerator,
+};
+
+const TEST_SIGNING_SEED: [u8; 32] = [
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+    0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f,
+];
+
+fn signing_key() -> SigningKey {
+    SigningKey::from_bytes(&TEST_SIGNING_SEED)
+}
+
+fn verifying_key() -> VerifyingKey {
+    signing_key().verifying_key()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_valid_bulletproof_range() {
-        let input = bulletproofs::BulletproofInput {
+        let input = BulletproofInput {
             weight_kg: 14500,
             max_limit_kg: 16200,
             blinding_factor: "secret_blind_123".to_string(),
         };
 
-        let res = bulletproofs::BulletproofsGenerator::prove_weight_range(&input);
+        let res = BulletproofsGenerator::prove_weight_range(&input, &signing_key());
         assert!(res.is_in_range);
-        assert!(bulletproofs::BulletproofsGenerator::verify_range_proof(&res, 16200));
+        assert!(BulletproofsGenerator::verify_range_proof(
+            &res, 16200, &verifying_key()
+        ));
     }
 
     #[test]
     fn test_invalid_overweight_bulletproof() {
-        let input = bulletproofs::BulletproofInput {
+        let input = BulletproofInput {
             weight_kg: 19000, // Over limit
             max_limit_kg: 16200,
             blinding_factor: "secret_blind_456".to_string(),
         };
 
-        let res = bulletproofs::BulletproofsGenerator::prove_weight_range(&input);
+        let res = BulletproofsGenerator::prove_weight_range(&input, &signing_key());
         assert!(!res.is_in_range);
-        assert!(!bulletproofs::BulletproofsGenerator::verify_range_proof(&res, 16200));
+        assert!(!BulletproofsGenerator::verify_range_proof(
+            &res, 16200, &verifying_key()
+        ));
     }
 
     #[test]
     fn test_forged_proof_with_false_in_range_flag_is_rejected() {
         // A malicious prover claims is_in_range = true while encoding an over-limit weight.
         // The verifier must derive in_range itself and reject the forged proof.
-        let forged = bulletproofs::BulletproofResult {
+        let forged = BulletproofResult {
             is_in_range: true,
             proof_bytes_hex: "0xbproof_4a38_7365637265745f626c696e645f3939".to_string(), // 0x4a38 = 19000
             commitment_hex: "0xcomm_4a38_secret_blind_99".to_string(),
+            signature_hex: hex::encode([0u8; 64]),
         };
-        assert!(!bulletproofs::BulletproofsGenerator::verify_range_proof(&forged, 16200));
+        assert!(!BulletproofsGenerator::verify_range_proof(
+            &forged, 16200, &verifying_key()
+        ));
     }
 
     #[test]
     fn test_inconsistent_proof_and_commitment_is_rejected() {
         // The proof and commitment disagree on the claimed weight; this must be rejected
         // rather than trusting the prover-supplied flag.
-        let forged = bulletproofs::BulletproofResult {
+        let forged = BulletproofResult {
             is_in_range: true,
             proof_bytes_hex: "0xbproof_38a4_7365637265745f626c696e645f3939".to_string(), // 0x38a4 = 14500
             commitment_hex: "0xcomm_4a38_secret_blind_99".to_string(), // 0x4a38 = 19000
+            signature_hex: hex::encode([0u8; 64]),
         };
-        assert!(!bulletproofs::BulletproofsGenerator::verify_range_proof(&forged, 16200));
+        assert!(!BulletproofsGenerator::verify_range_proof(
+            &forged, 16200, &verifying_key()
+        ));
+    }
+
+    #[test]
+    fn test_self_asserted_in_range_weight_without_signature_is_rejected() {
+        // The core vulnerability: a prover encodes an arbitrary in-range weight
+        // (here 5000 <= 16200) but supplies no valid device signature. The
+        // verifier must reject it because the weight is not cryptographically
+        // bound to the device key.
+        let forged = BulletproofResult {
+            is_in_range: true,
+            proof_bytes_hex: "0xbproof_1388_7365637265745f626c696e645f3939".to_string(), // 0x1388 = 5000
+            commitment_hex: "0xcomm_1388_secret_blind_99".to_string(),
+            signature_hex: hex::encode([0u8; 64]),
+        };
+        assert!(!BulletproofsGenerator::verify_range_proof(
+            &forged, 16200, &verifying_key()
+        ));
+    }
+
+    #[test]
+    fn test_forged_signature_from_wrong_key_is_rejected() {
+        // A genuine-looking claim signed by an attacker's key (not the device
+        // key) must be rejected, even when the encoded weight is in range.
+        let weight: u64 = 14500;
+        let blinding = "secret_blind_123".to_string();
+        let proof = format!("0xbproof_{:x}_{}", weight, hex::encode(&blinding));
+        let commitment = format!("0xcomm_{:x}_{}", weight, blinding);
+
+        // Sign with a key that is NOT the device key, then reuse only the signature.
+        let attacker_key = SigningKey::from_bytes(&[0xaa; 32]);
+        let signature_hex = BulletproofsGenerator::prove_weight_range(
+            &BulletproofInput {
+                weight_kg: weight,
+                max_limit_kg: 16200,
+                blinding_factor: "secret_blind_123".to_string(),
+            },
+            &attacker_key,
+        )
+        .signature_hex;
+
+        let forged = BulletproofResult {
+            is_in_range: true,
+            proof_bytes_hex: proof,
+            commitment_hex: commitment,
+            signature_hex,
+        };
+        assert!(!BulletproofsGenerator::verify_range_proof(
+            &forged, 16200, &verifying_key()
+        ));
+    }
+
+    #[test]
+    fn test_tampered_weight_after_signing_is_rejected() {
+        // Even a device-signed proof must fail if the weight is altered after
+        // signing, proving the signature actually binds the weight.
+        let input = BulletproofInput {
+            weight_kg: 14500,
+            max_limit_kg: 16200,
+            blinding_factor: "secret_blind_123".to_string(),
+        };
+        let mut res = BulletproofsGenerator::prove_weight_range(&input, &signing_key());
+        // Attacker changes the encoded weight to a smaller in-range value.
+        res.proof_bytes_hex = "0xbproof_1388_7365637265745f626c696e645f3939".to_string(); // 5000
+        res.commitment_hex = "0xcomm_1388_secret_blind_123".to_string();
+        assert!(!BulletproofsGenerator::verify_range_proof(
+            &res, 16200, &verifying_key()
+        ));
     }
 }


### PR DESCRIPTION
## Problem

`verify_range_proof` in `services/zkp-verifier-rust/src/bulletproofs.rs` performed no real cryptographic verification. It decoded the claimed weight directly from the attacker-controlled proof string (`proof_parts[1]`) and only checked `proof_weight <= max_allowed`. A prover could encode any self-asserted in-range weight into `proof_bytes_hex` and the verifier returned `true`, completely defeating weight-limit enforcement. The existing tests only caught the naive over-limit case and never tested a prover lying about the weight.

## Fix

Bind the committed weight to an Ed25519 signature produced by the weighing device's secret key (mirroring the `verifier.rs::verify_proof` pattern already used for `WeightProofOutput`):

- `BulletproofResult` now carries a `signature_hex` field: an Ed25519 signature over the canonical payload `(weight, blinding)`.
- `prove_weight_range` takes the device `SigningKey` and signs the exact `(weight, blinding)` the proof encodes.
- `verify_range_proof` takes the device `VerifyingKey` and only accepts the claimed weight after verifying the signature covers that exact `(weight, blinding)`. The prover's self-asserted `is_in_range` flag is still ignored; the in-range decision is derived from the verified weight.

A forged or self-asserted weight cannot carry a valid signature from the device key, so it is rejected even when the encoded weight is within the limit. Also removed a duplicate `pub mod bulletproofs;` in `lib.rs` that prevented the crate from compiling.

## Files changed

- `services/zkp-verifier-rust/src/bulletproofs.rs` — real signature-based verification; added `signature_hex`.
- `services/zkp-verifier-rust/src/lib.rs` — removed duplicate `bulletproofs` module declaration.
- `services/zkp-verifier-rust/tests/bulletproof_test.rs` — updated to new API; added forgery tests (self-asserted in-range weight, wrong-key signature, post-signing weight tamper).

## Testing

- `test_valid_bulletproof_range` — genuine device-signed in-range proof verifies.
- `test_invalid_overweight_bulletproof` — genuine overweight proof rejected.
- `test_forged_proof_with_false_in_range_flag_is_rejected` — over-limit weight (matching proof/commitment) rejected.
- `test_inconsistent_proof_and_commitment_is_rejected` — mismatched proof/commitment rejected.
- `test_self_asserted_in_range_weight_without_signature_is_rejected` — core regression: arbitrary in-range weight with no valid signature is rejected.
- `test_forged_signature_from_wrong_key_is_rejected` — signature from a non-device key rejected.
- `test_tampered_weight_after_signing_is_rejected` — weight altered after signing rejected.

Closes #14678
