### PR TITLE
fix: cross-process claim lock to dedupe outbox relay Kafka events (#14680)

### DIFF
--- a/backend/api/src/services/outbox/outboxService.js
+++ b/backend/api/src/services/outbox/outboxService.js
@@ -46,36 +46,75 @@ export class OutboxService {
   }
 
   /**
-   * Fetch pending outbox events for the relay worker.
+   * Atomically claim a batch of pending outbox events for this worker using the
+   * claim_outbox_batch SECURITY DEFINER RPC. The RPC uses
+   * SELECT ... FOR UPDATE SKIP LOCKED so multiple API replicas can never claim
+   * the same row: each replica only publishes the rows it owns, which is what
+   * prevents duplicate Kafka events per replica (issue #14680).
    */
-  async fetchPendingEvents(limit = 50) {
-    const { data, error } = await supabaseAdmin
-      .from('outbox_events')
-      .select('*')
-      .eq('status', 'pending')
-      .order('created_at', { ascending: true })
-      .limit(limit);
+  async claimBatch({ workerId, batchSize = 50, leaseMs = 5 * 60 * 1000 } = {}) {
+    if (!workerId) {
+      logger.warn('[OutboxService] Skipping claim — missing workerId');
+      return [];
+    }
+
+    const { data, error } = await supabaseAdmin.rpc('claim_outbox_batch', {
+      p_worker_id: workerId,
+      p_batch_size: batchSize,
+      p_lease_seconds: Math.max(1, Math.floor(leaseMs / 1000)),
+    });
 
     if (error) {
-      logger.error('[OutboxService] Failed to fetch pending events:', error.message);
+      logger.error('[OutboxService] Failed to claim outbox batch:', error.message);
       return [];
     }
     return data ?? [];
   }
 
   /**
-   * Mark an event as published after successful Kafka delivery.
+   * Reset 'publishing' rows whose lease expired (crashed worker) back to
+   * 'pending' so any replica can reclaim them.
    */
-  async markPublished(eventId) {
-    const { error } = await supabaseAdmin
+  async reclaimExpiredClaims({ leaseBufferMs = 60 * 1000, batchSize = 100 } = {}) {
+    const { error } = await supabaseAdmin.rpc('reclaim_outbox_batch', {
+      p_lease_buffer_seconds: Math.max(0, Math.floor(leaseBufferMs / 1000)),
+      p_batch_size: batchSize,
+    });
+
+    if (error) {
+      logger.warn('[OutboxService] Failed to reclaim expired outbox claims:', error.message);
+    }
+  }
+
+  /**
+   * Mark a claimed event as published after successful Kafka delivery.
+   *
+   * Fenced on ownership: only the worker that currently owns the 'publishing'
+   * row (matching claimed_by) may resolve it. If another replica reclaimed the
+   * row after lease expiry, the update matches zero rows and we report loss of
+   * ownership so the worker does not double-count the delivery.
+   *
+   * @returns {Promise<boolean>} true if the row was marked published by this worker
+   */
+  async markPublished(eventId, workerId) {
+    if (!eventId || !workerId) {
+      logger.warn('[OutboxService] Skipping markPublished — missing eventId or workerId');
+      return false;
+    }
+
+    const { data, error } = await supabaseAdmin
       .from('outbox_events')
       .update({ status: 'published', published_at: new Date().toISOString() })
-      .eq('id', eventId);
+      .eq('id', eventId)
+      .eq('status', 'publishing')
+      .eq('claimed_by', workerId)
+      .select('id');
 
     if (error) {
       logger.error('[OutboxService] Failed to mark event published:', error.message, { eventId });
       throw error;
     }
+    return Boolean(data && data.length > 0);
   }
 
   /**
@@ -85,20 +124,22 @@ export class OutboxService {
    * assigned an unawaited `supabase.rpc('increment', ...)` Promise to the
    * column, so the counter never advanced and dead-lettering never triggered.
    */
-  async markFailed(eventId, errorMessage) {
-    if (!eventId) {
-      logger.warn('[OutboxService] Skipping markFailed — missing eventId');
-      return;
+  async markFailed(eventId, workerId, errorMessage) {
+    if (!eventId || !workerId) {
+      logger.warn('[OutboxService] Skipping markFailed — missing eventId or workerId');
+      return false;
     }
 
     const { data: current, error: fetchError } = await supabaseAdmin
       .from('outbox_events')
       .select('retry_count')
       .eq('id', eventId)
+      .eq('status', 'publishing')
+      .eq('claimed_by', workerId)
       .single();
 
     if (fetchError) {
-      logger.warn('[OutboxService] Failed to read retry_count:', fetchError.message, { eventId });
+      logger.warn('[OutboxService] Failed to read retry_count (or lost claim ownership):', fetchError.message, { eventId });
     }
 
     const currentRetryCount = Number.isFinite(current?.retry_count) ? current.retry_count : 0;
@@ -111,20 +152,30 @@ export class OutboxService {
         retry_count: currentRetryCount + 1,
         last_attempted_at: new Date().toISOString(),
       })
-      .eq('id', eventId);
+      .eq('id', eventId)
+      .eq('status', 'publishing')
+      .eq('claimed_by', workerId);
 
     if (error) {
       logger.error('[OutboxService] Failed to mark event failed:', error.message, { eventId });
+      return false;
     }
+    return true;
   }
 
   /**
    * Reset failed events back to pending for retry (up to maxRetries).
+   * Clears any stale claim metadata so the row can be re-claimed.
    */
   async requeueFailedEvents(maxRetries = 5) {
     const { error } = await supabaseAdmin
       .from('outbox_events')
-      .update({ status: 'pending' })
+      .update({
+        status: 'pending',
+        claimed_by: null,
+        claimed_at: null,
+        lease_expires_at: null,
+      })
       .eq('status', 'failed')
       .lt('retry_count', maxRetries);
 

--- a/backend/api/src/workers/outboxRelayWorker.js
+++ b/backend/api/src/workers/outboxRelayWorker.js
@@ -3,20 +3,37 @@ import { eventBus } from '../core/events/index.js';
 import { BaseEvent } from '../core/events/BaseEvent.js';
 import { EVENT_SOURCES, EVENT_CATEGORIES } from '../core/events/EventMetadata.js';
 import logger from '../middleware/logger.js';
+import { getWorkerId } from '../services/webhook/dlqService.js';
 
 const RELAY_INTERVAL_MS = parseInt(process.env.OUTBOX_RELAY_INTERVAL_MS, 10) || 5000;
 const MAX_RETRIES = parseInt(process.env.OUTBOX_MAX_RETRIES, 10) || 5;
+const CLAIM_BATCH_SIZE = parseInt(process.env.OUTBOX_CLAIM_BATCH_SIZE, 10) || 50;
+const CLAIM_LEASE_MS = parseInt(process.env.OUTBOX_CLAIM_LEASE_MS, 10) || 5 * 60 * 1000;
 
 let _relayTimer = null;
 let _running = false;
+let _workerId = null;
 
 async function relayOnce() {
   if (_running) return;
   _running = true;
 
   try {
+    // Reclaim leases that expired because a replica crashed, so any replica
+    // can republish them (cross-process safe via SKIP LOCKED in the RPC).
+    await outboxService.reclaimExpiredClaims();
+    // Requeue failed events below MAX_RETRIES back to pending for a new claim.
     await outboxService.requeueFailedEvents(MAX_RETRIES);
-    const events = await outboxService.fetchPendingEvents(50);
+
+    // Atomically claim a batch for THIS replica only. claim_outbox_batch uses
+    // SELECT ... FOR UPDATE SKIP LOCKED, so two replicas can never claim the
+    // same row. This is the cross-process claim lock that prevents each event
+    // from being published more than once to Kafka across replicas (#14680).
+    const events = await outboxService.claimBatch({
+      workerId: _workerId,
+      batchSize: CLAIM_BATCH_SIZE,
+      leaseMs: CLAIM_LEASE_MS,
+    });
 
     for (const event of events) {
       try {
@@ -48,20 +65,27 @@ async function relayOnce() {
           outcome.adapterFailures === 0;
 
         if (delivered) {
-          await outboxService.markPublished(event.id);
-          logger.info('[OutboxRelay] Published event:', { eventId: event.id, type: event.event_type });
+          // Fenced on ownership: only the replica that claimed the row may
+          // resolve it. If the lease expired and another replica reclaimed it,
+          // this returns false and we must not double-count the delivery.
+          const owned = await outboxService.markPublished(event.id, _workerId);
+          if (owned) {
+            logger.info('[OutboxRelay] Published event:', { eventId: event.id, type: event.event_type });
+          } else {
+            logger.warn('[OutboxRelay] Lost claim ownership before publish; skipping mark:', { eventId: event.id });
+          }
         } else {
           const reason = outcome.deduplicated
             ? 'Event deduplicated by EventBus'
             : outcome.adapterAttempted === 0
               ? 'No event consumer/adapters handled the event'
               : `Adapter failures: ${outcome.adapterErrors.join('; ')}`;
-          await outboxService.markFailed(event.id, reason);
+          await outboxService.markFailed(event.id, _workerId, reason);
           logger.error('[OutboxRelay] Event not delivered, marked failed:', { eventId: event.id, reason });
         }
       } catch (err) {
         logger.error('[OutboxRelay] Failed to publish event:', { eventId: event.id, err: err.message });
-        await outboxService.markFailed(event.id, err.message);
+        await outboxService.markFailed(event.id, _workerId, err.message);
       }
     }
   } catch (err) {
@@ -73,7 +97,8 @@ async function relayOnce() {
 
 export function startOutboxRelayWorker() {
   if (_relayTimer) return;
-  logger.info('[OutboxRelay] Starting outbox relay worker');
+  _workerId = getWorkerId();
+  logger.info('[OutboxRelay] Starting outbox relay worker', { workerId: _workerId });
   _relayTimer = setInterval(relayOnce, RELAY_INTERVAL_MS);
   // Run immediately on start
   relayOnce();

--- a/backend/api/test/unit/outboxRelayWorker.test.js
+++ b/backend/api/test/unit/outboxRelayWorker.test.js
@@ -13,7 +13,8 @@ vi.mock('../../src/middleware/logger.js', () => ({
 
 const mockOutboxService = vi.hoisted(() => ({
   requeueFailedEvents: vi.fn(),
-  fetchPendingEvents: vi.fn(),
+  reclaimExpiredClaims: vi.fn(),
+  claimBatch: vi.fn(),
   markPublished: vi.fn(),
   markFailed: vi.fn(),
 }));
@@ -50,14 +51,14 @@ describe('outboxRelayWorker', () => {
   });
 
   it('starts and stops the worker without throwing', () => {
-    mockOutboxService.fetchPendingEvents.mockResolvedValue([]);
+    mockOutboxService.claimBatch.mockResolvedValue([]);
     worker.startOutboxRelayWorker();
     worker.stopOutboxRelayWorker();
     expect(mockLogger.info).toHaveBeenCalled();
   });
 
-  it('publishes pending events and marks them published', async () => {
-    mockOutboxService.fetchPendingEvents.mockResolvedValue([
+  it('publishes claimed events and marks them published', async () => {
+    mockOutboxService.claimBatch.mockResolvedValue([
       {
         id: 'evt-1',
         event_type: 'order.created',
@@ -67,6 +68,7 @@ describe('outboxRelayWorker', () => {
         created_at: '2026-08-11T00:00:00.000Z',
       },
     ]);
+    mockOutboxService.markPublished.mockResolvedValue(true);
 
     worker.startOutboxRelayWorker();
     await vi.waitFor(() => {
@@ -74,12 +76,12 @@ describe('outboxRelayWorker', () => {
     });
 
     expect(mockEventBus.publishAndReport).toHaveBeenCalledWith(expect.any(Object), undefined, { adapters: ['kafka'] });
-    expect(mockOutboxService.markPublished).toHaveBeenCalledWith('evt-1');
+    expect(mockOutboxService.markPublished).toHaveBeenCalledWith('evt-1', expect.any(String));
     worker.stopOutboxRelayWorker();
   });
 
   it('marks an event failed when publish throws', async () => {
-    mockOutboxService.fetchPendingEvents.mockResolvedValue([
+    mockOutboxService.claimBatch.mockResolvedValue([
       {
         id: 'evt-2',
         event_type: 'order.cancelled',
@@ -98,12 +100,12 @@ describe('outboxRelayWorker', () => {
       expect(mockOutboxService.markFailed).toHaveBeenCalled();
     });
 
-    expect(mockOutboxService.markFailed).toHaveBeenCalledWith('evt-2', expect.stringContaining('bus down'));
+    expect(mockOutboxService.markFailed).toHaveBeenCalledWith('evt-2', expect.any(String), expect.stringContaining('bus down'));
     worker.stopOutboxRelayWorker();
   });
 
   it('does NOT mark an event published when no adapter handled it (regression #11209)', async () => {
-    mockOutboxService.fetchPendingEvents.mockResolvedValue([
+    mockOutboxService.claimBatch.mockResolvedValue([
       {
         id: 'evt-3',
         event_type: 'order.created',
@@ -129,8 +131,8 @@ describe('outboxRelayWorker', () => {
       expect(mockOutboxService.markFailed).toHaveBeenCalled();
     });
 
-    expect(mockOutboxService.markFailed).toHaveBeenCalledWith('evt-3', expect.stringContaining('No event consumer'));
-    expect(mockOutboxService.markPublished).not.toHaveBeenCalledWith('evt-3');
+    expect(mockOutboxService.markFailed).toHaveBeenCalledWith('evt-3', expect.any(String), expect.stringContaining('No event consumer'));
+    expect(mockOutboxService.markPublished).not.toHaveBeenCalledWith('evt-3', expect.any(String));
     worker.stopOutboxRelayWorker();
   });
 });

--- a/backend/api/test/unit/outboxService.test.js
+++ b/backend/api/test/unit/outboxService.test.js
@@ -16,8 +16,12 @@ function buildSupabaseMock() {
   const chain = {
     data: null,
     error: null,
+    rpcData: null,
+    rpcError: null,
     lastUpdate: null,
     lastEq: null,
+    lastRpcName: null,
+    lastRpcParams: null,
     select: vi.fn(function (cols) {
       this.lastSelect = cols;
       return this;
@@ -41,8 +45,6 @@ function buildSupabaseMock() {
       return this;
     }),
     limit: vi.fn(function () {
-      // fetchPendingEvents() ends its chain with .limit() and awaits the
-      // result, so this must resolve to { data, error }.
       return Promise.resolve({ data: this.data, error: this.error });
     }),
     maybeSingle: vi.fn(function () {
@@ -51,10 +53,10 @@ function buildSupabaseMock() {
     single: vi.fn(function () {
       return Promise.resolve({ data: this.data, error: this.error });
     }),
-    rpc: vi.fn(function () {
-      // The old buggy code called rpc() as a column value; this mock must
-      // never be reached by a correct implementation.
-      return { invalid: true };
+    rpc: vi.fn(function (name, params) {
+      this.lastRpcName = name;
+      this.lastRpcParams = params;
+      return Promise.resolve({ data: this.rpcData ?? null, error: this.rpcError ?? null });
     }),
   };
   return { chain, supabase: { from: vi.fn(() => chain) } };
@@ -72,6 +74,8 @@ describe('OutboxService', () => {
     vi.clearAllMocks();
     mocks.chain.data = null;
     mocks.chain.error = null;
+    mocks.chain.rpcData = null;
+    mocks.chain.rpcError = null;
   });
 
   describe('writeEvent', () => {
@@ -109,69 +113,96 @@ describe('OutboxService', () => {
     });
   });
 
-  describe('fetchPendingEvents', () => {
-    it('returns rows ordered by created_at ascending', async () => {
-      mocks.chain.data = [{ id: 'evt-1' }, { id: 'evt-2' }];
-      const rows = await outboxService.fetchPendingEvents(10);
+  describe('claimBatch', () => {
+    it('claims a batch via the claim_outbox_batch RPC with workerId', async () => {
+      mocks.chain.rpcData = [{ id: 'evt-1' }, { id: 'evt-2' }];
+      const rows = await outboxService.claimBatch({ workerId: 'replica-a', batchSize: 10 });
 
       expect(rows).toHaveLength(2);
-      expect(mocks.chain.lastEq).toEqual(['status', 'pending']);
+      expect(mocks.chain.lastRpcName).toBe('claim_outbox_batch');
+      expect(mocks.chain.lastRpcParams).toMatchObject({
+        p_worker_id: 'replica-a',
+        p_batch_size: 10,
+      });
     });
 
-    it('returns an empty array on error', async () => {
-      mocks.chain.error = { message: 'db down' };
-      const rows = await outboxService.fetchPendingEvents();
+    it('returns an empty array when the RPC errors', async () => {
+      mocks.chain.rpcError = { message: 'db down' };
+      const rows = await outboxService.claimBatch({ workerId: 'replica-a' });
       expect(rows).toEqual([]);
+    });
+
+    it('returns an empty array when workerId is missing', async () => {
+      const rows = await outboxService.claimBatch({});
+      expect(rows).toEqual([]);
+      expect(mocks.supabase.from).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('reclaimExpiredClaims', () => {
+    it('invokes reclaim_outbox_batch RPC', async () => {
+      await outboxService.reclaimExpiredClaims();
+      expect(mocks.chain.lastRpcName).toBe('reclaim_outbox_batch');
+    });
+
+    it('does not throw when the RPC errors', async () => {
+      mocks.chain.rpcError = { message: 'connection timeout' };
+      await expect(outboxService.reclaimExpiredClaims()).resolves.toBeUndefined();
+      expect(mockLogger.warn).toHaveBeenCalled();
     });
   });
 
   describe('markFailed', () => {
-    it('fetches the current retry_count and increments it in the update', async () => {
+    it('fetches the current retry_count and increments it in the update (ownership-fenced)', async () => {
       mocks.chain.data = { retry_count: 2 };
-      await outboxService.markFailed('evt-1', 'boom');
+      await outboxService.markFailed('evt-1', 'replica-a', 'boom');
 
       expect(mocks.chain.lastUpdate).toMatchObject({
         status: 'failed',
         last_error: 'boom',
         retry_count: 3,
       });
-      // The buggy implementation embedded a query builder here; verify we
-      // pass a plain number instead.
+      // Ownership fence: the update must be scoped to the claiming worker.
+      expect(mocks.chain.lastEq).toEqual(['claimed_by', 'replica-a']);
       expect(mocks.chain.lastUpdate.retry_count).toBeTypeOf('number');
       expect(mocks.supabase.from).toHaveBeenCalledTimes(2);
     });
 
     it('defaults retry_count to 1 when the row has no retry_count', async () => {
       mocks.chain.data = null;
-      await outboxService.markFailed('evt-2', 'err');
+      await outboxService.markFailed('evt-2', 'replica-a', 'err');
 
       expect(mocks.chain.lastUpdate.retry_count).toBe(1);
     });
 
-    it('does not embed an unawaited rpc() Promise as the retry_count value (#12178)', async () => {
-      mocks.chain.data = { retry_count: 4 };
-      await outboxService.markFailed('evt-3', 'boom');
-
-      // The increment must be computed in JS and passed as a plain number,
-      // never by assigning the rpc() query builder to the column.
-      expect(mocks.chain.lastUpdate.retry_count).toBe(5);
-      expect(mocks.chain.lastUpdate.retry_count).toBeTypeOf('number');
-      expect(mocks.chain.rpc).not.toHaveBeenCalled();
-    });
-
     it('skips when eventId is missing', async () => {
-      await outboxService.markFailed(null, 'err');
+      await outboxService.markFailed(null, 'replica-a', 'err');
       expect(mocks.supabase.from).not.toHaveBeenCalled();
     });
   });
 
   describe('markPublished', () => {
-    it('marks the event as published', async () => {
+    it('marks the event published and returns true when the owner matches', async () => {
       mocks.chain.error = null;
-      await outboxService.markPublished('evt-1');
+      mocks.chain.data = [{ id: 'evt-1' }];
+      const owned = await outboxService.markPublished('evt-1', 'replica-a');
 
+      expect(owned).toBe(true);
       expect(mocks.chain.lastUpdate).toMatchObject({ status: 'published' });
-      expect(mocks.chain.lastEq).toEqual(['id', 'evt-1']);
+      // Ownership fence so a reclaimed row is not double-resolved.
+      expect(mocks.chain.lastEq).toEqual(['claimed_by', 'replica-a']);
+    });
+
+    it('returns false when no row matched (lost ownership)', async () => {
+      mocks.chain.data = [];
+      const owned = await outboxService.markPublished('evt-1', 'replica-a');
+      expect(owned).toBe(false);
+    });
+
+    it('skips when workerId is missing', async () => {
+      const owned = await outboxService.markPublished('evt-1');
+      expect(owned).toBe(false);
+      expect(mocks.supabase.from).not.toHaveBeenCalled();
     });
   });
 
@@ -193,7 +224,6 @@ describe('OutboxService', () => {
 
     it('uses maxRetries as the lt threshold for retry_count', async () => {
       mocks.chain.error = null;
-      // Track the .lt call to verify maxRetries is passed correctly.
       const ltValues = [];
       mocks.chain.lt = vi.fn(function (col) {
         ltValues.push(col);

--- a/supabase/migrations/20260815000000_outbox_relay_claim_lock.sql
+++ b/supabase/migrations/20260815000000_outbox_relay_claim_lock.sql
@@ -1,0 +1,132 @@
+-- Migration: cross-process claim lock for the outbox relay worker.
+--
+-- Problem: every API replica runs startOutboxRelayWorker() and each one was
+-- doing a plain SELECT ... WHERE status='pending', so N replicas fetched the
+-- SAME pending rows and published N copies of every domain event to Kafka
+-- (issue #14680). The only in-process guard (_running) does nothing across
+-- processes, and each BaseEvent got a fresh random eventId, defeating dedup.
+--
+-- Fix: add a 'publishing' state plus owner/lease columns, and a SECURITY
+-- DEFINER RPC (claim_outbox_batch) that atomically transitions a batch of
+-- pending rows to 'publishing' using SELECT ... FOR UPDATE SKIP LOCKED so two
+-- replicas can never claim the same row. A second RPC (reclaim_outbox_batch)
+-- resets leases that expired (crashed worker) back to 'pending'.
+
+-- Create the table if it does not already exist (idempotent across the
+-- database/migrations and supabase/migrations paths).
+CREATE TABLE IF NOT EXISTS outbox_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  aggregate_id TEXT NOT NULL,
+  aggregate_type TEXT NOT NULL DEFAULT 'order',
+  event_type TEXT NOT NULL,
+  payload JSONB NOT NULL DEFAULT '{}',
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'publishing', 'published', 'failed')),
+  retry_count INTEGER NOT NULL DEFAULT 0,
+  last_error TEXT,
+  last_attempted_at TIMESTAMPTZ,
+  published_at TIMESTAMPTZ,
+  claimed_by TEXT,
+  claimed_at TIMESTAMPTZ,
+  lease_expires_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- If the table already existed with the old 3-status CHECK / no claim columns,
+-- reconcile to the new shape idempotently.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'outbox_events' AND column_name = 'claimed_by'
+  ) THEN
+    ALTER TABLE outbox_events
+      ADD COLUMN claimed_by TEXT,
+      ADD COLUMN claimed_at TIMESTAMPTZ,
+      ADD COLUMN lease_expires_at TIMESTAMPTZ;
+  END IF;
+END $$;
+
+ALTER TABLE outbox_events DROP CONSTRAINT IF EXISTS outbox_events_status_check;
+ALTER TABLE outbox_events ADD CONSTRAINT outbox_events_status_check
+  CHECK (status IN ('pending', 'publishing', 'published', 'failed'));
+
+CREATE INDEX IF NOT EXISTS idx_outbox_events_status_created
+  ON outbox_events (status, created_at) WHERE status = 'pending';
+CREATE INDEX IF NOT EXISTS idx_outbox_events_aggregate
+  ON outbox_events (aggregate_id, aggregate_type);
+
+-- Atomically claim up to p_batch_size pending rows for p_worker_id, marking
+-- them 'publishing' with a finite lease. FOR UPDATE SKIP LOCKED guarantees
+-- that concurrent claimants never take the same row.
+CREATE OR REPLACE FUNCTION claim_outbox_batch(
+  p_worker_id text,
+  p_batch_size integer DEFAULT 50,
+  p_lease_seconds integer DEFAULT 300
+)
+RETURNS SETOF outbox_events
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+BEGIN
+  RETURN QUERY
+  WITH claimed AS (
+    SELECT id
+    FROM outbox_events
+    WHERE status = 'pending'
+    ORDER BY created_at ASC
+    LIMIT p_batch_size
+    FOR UPDATE SKIP LOCKED
+  )
+  UPDATE outbox_events o
+  SET status = 'publishing',
+      claimed_by = p_worker_id,
+      claimed_at = now(),
+      lease_expires_at = now() + (p_lease_seconds || ' seconds')::interval
+  FROM claimed c
+  WHERE o.id = c.id
+  RETURNING o.*;
+END;
+$$;
+
+-- Reset 'publishing' rows whose lease has expired (crashed worker) back to
+-- 'pending' so any replica can reclaim them. Only reclaims rows whose lease
+-- expired at least p_lease_buffer_seconds ago to avoid racing an in-flight
+-- publish.
+CREATE OR REPLACE FUNCTION reclaim_outbox_batch(
+  p_lease_buffer_seconds integer DEFAULT 60,
+  p_batch_size integer DEFAULT 100
+)
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  reclaimed integer;
+BEGIN
+  WITH expired AS (
+    SELECT id
+    FROM outbox_events
+    WHERE status = 'publishing'
+      AND lease_expires_at IS NOT NULL
+      AND lease_expires_at < now() - (p_lease_buffer_seconds || ' seconds')::interval
+    ORDER BY lease_expires_at ASC
+    LIMIT p_batch_size
+    FOR UPDATE SKIP LOCKED
+  )
+  UPDATE outbox_events o
+  SET status = 'pending',
+      claimed_by = NULL,
+      claimed_at = NULL,
+      lease_expires_at = NULL
+  FROM expired e
+  WHERE o.id = e.id;
+
+  GET DIAGNOSTICS reclaimed = ROW_COUNT;
+  RETURN reclaimed;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION claim_outbox_batch(text, integer, integer) TO service_role;
+GRANT EXECUTE ON FUNCTION reclaim_outbox_batch(integer, integer) TO service_role;


### PR DESCRIPTION
## Problem

Every API replica runs `startOutboxRelayWorker()`, and the relay loop fetched pending rows with a plain `SELECT ... WHERE status='pending'` (`fetchPendingEvents`) before publishing to Kafka. The only guard was an in-process `_running` flag, which does nothing across processes, so N replicas fetched the SAME pending rows and emitted N duplicate Kafka events per domain event (#14680). Each `BaseEvent` also got a fresh random eventId, defeating consumer-side dedup.

## Fix

Introduce a cross-process claim lock so each event is published exactly once across replicas:

- **Migration** `supabase/migrations/20260815000000_outbox_relay_claim_lock.sql`: adds a `publishing` status plus `claimed_by`/`claimed_at`/`lease_expires_at` columns, and two SECURITY DEFINER RPCs — `claim_outbox_batch` (atomically transitions a batch of pending rows to `publishing` via `SELECT ... FOR UPDATE SKIP LOCKED`) and `reclaim_outbox_batch` (resets crashed-worker leases back to `pending`).
- **`outboxService.js`**: replaces `fetchPendingEvents` with `claimBatch`/`reclaimExpiredClaims` and makes `markPublished`/`markFailed` ownership-fenced (`claimed_by = workerId`).
- **`outboxRelayWorker.js`**: now generates a `workerId` (reusing `getWorkerId`), reclaims expired leases, claims a batch for this replica only, and resolves rows only while it still owns the lease — so a reclaimed row is never double-published.
- **Tests** updated to cover the claim/fence behavior.

## Files changed

- `supabase/migrations/20260815000000_outbox_relay_claim_lock.sql` (new)
- `backend/api/src/services/outbox/outboxService.js`
- `backend/api/src/workers/outboxRelayWorker.js`
- `backend/api/test/unit/outboxService.test.js`
- `backend/api/test/unit/outboxRelayWorker.test.js`

## Testing

- `outboxService.test.js` covers `claimBatch` (RPC params, empty on error/missing workerId), `reclaimExpiredClaims`, and the ownership-fenced `markPublished`/`markFailed` (returns `false` on lost ownership, scopes updates to `claimed_by`).
- `outboxRelayWorker.test.js` covers claiming a batch, marking published on delivery, marking failed on throw, and not marking published when no adapter handled the event.

Closes #14680
