### PR TITLE
security: authenticate /api/mev escrow funding/release endpoints (#14673)

### DIFF
--- a/backend/api/src/security/policyEngine.js
+++ b/backend/api/src/security/policyEngine.js
@@ -154,6 +154,11 @@ const POLICIES = {
   'crossdock:verify':           {},
   'crossdock:view':             { ownership: (u, r) => r?.transfer && (u.role === ROLES.ADMIN || r.transfer.from_driver_id === u.id || r.transfer.to_driver_id === u.id) },
   'crossdock:list':             {},
+
+  // MEV escrow subsystem (#14673): escrow funding/release spend server funds,
+  // so every state-changing action must be authenticated and authorized.
+  'mev:escrow':               { roles: [ROLES.CUSTOMER, ROLES.DRIVER, ROLES.ADMIN] },
+  'mev:flashbots':            { roles: [ROLES.ADMIN] },
 };
 
 export class PolicyEngine {

--- a/backend/mev/mev.service.js
+++ b/backend/mev/mev.service.js
@@ -111,6 +111,9 @@ class MEVService {
     // ============ MEV Protected Escrow ============
 
     async createEscrow(driver, amount, secret, userId) {
+        if (!userId) {
+            throw new Error('Authenticated user context is required to create an escrow.');
+        }
         try {
             // Create commitment first
             const commitment = await this.createCommitment(secret, userId);
@@ -141,6 +144,7 @@ class MEVService {
                 customer: this.wallet.address,
                 driver,
                 amount,
+                userId,
                 commitHash: secretHash,
                 secretHash,
                 txHash: receipt.hash
@@ -176,8 +180,39 @@ class MEVService {
 
     // ============ Release with MEV Protection ============
 
-    async releaseEscrow(escrowId, secret) {
+    async releaseEscrow(escrowId, secret, proof, user) {
         try {
+            if (!user || !user.id) {
+                throw new Error('Authentication required to release an escrow.');
+            }
+
+            // On-chain sanity: the deposit must exist and must not already be
+            // released. Without this, a replayed or stale release could be
+            // submitted against an already-settled deposit.
+            const deposit = await this.escrow.deposits(escrowId);
+            if (!deposit || deposit[2] === 0n) {
+                await this.updateEscrowStatus(escrowId, 'not_found').catch(() => {});
+                throw new Error(`Escrow ${escrowId} does not exist.`);
+            }
+            if (deposit[3]) {
+                throw new Error(`Escrow ${escrowId} has already been released.`);
+            }
+
+            // Authorization: the caller must be the user who created this
+            // escrow (or an admin). `secret` is not an authorization mechanism;
+            // anyone could know it, so ownership is enforced server-side
+            // against the stored deposit record (#14673).
+            const stored = await this.getStoredEscrow(escrowId);
+            if (stored) {
+                if (user.role !== 'admin' && stored.user_id !== user.id) {
+                    logger.warn(
+                        { userId: user.id, escrowId, owner: stored.user_id },
+                        'Escrow release denied: caller is not the deposit owner'
+                    );
+                    throw new Error('Forbidden: you are not authorized to release this escrow.');
+                }
+            }
+
             const tx = await this.escrow.releaseDepositPrivate(
                 escrowId,
                 secret,
@@ -195,6 +230,21 @@ class MEVService {
         } catch (error) {
             logger.error('Escrow release failed:', error);
             throw error;
+        }
+    }
+
+    async getStoredEscrow(escrowId) {
+        try {
+            const { data, error } = await supabase
+                .from('mev_escrows')
+                .select('user_id, escrow_id')
+                .eq('escrow_id', escrowId)
+                .maybeSingle();
+            if (error) throw error;
+            return data || null;
+        } catch (error) {
+            logger.error('Stored escrow lookup failed:', error);
+            return null;
         }
     }
 
@@ -298,6 +348,7 @@ class MEVService {
                 customer: data.customer,
                 driver: data.driver,
                 amount: data.amount,
+                user_id: data.userId,
                 commit_hash: data.commitHash,
                 secret_hash: data.secretHash,
                 tx_hash: data.txHash,

--- a/backend/mev/routes.js
+++ b/backend/mev/routes.js
@@ -2,11 +2,17 @@ import { ethers } from 'ethers';
 import express from 'express';
 import mevService from './mev.service.js';
 import logger from '../api/src/middleware/logger.js';
+import { authenticate, requirePolicy } from '../api/src/middleware/index.js';
 
 const router = express.Router();
 
+// All MEV routes require an authenticated user: the escrow subsystem spends
+// server funds (relayer wallet) on create/release and submits Flashbots
+// bundles via the relayer, so it must never be publicly reachable (#14673).
+router.use(authenticate);
+
 // Create commitment
-router.post('/mev/commitment', async (req, res) => {
+router.post('/mev/commitment', requirePolicy('mev:escrow'), async (req, res) => {
     try {
         const { secret, userId } = req.body;
         if (!secret) {
@@ -25,17 +31,26 @@ router.post('/mev/commitment', async (req, res) => {
 });
 
 // Create MEV protected escrow
-router.post('/mev/escrow', async (req, res) => {
+router.post('/mev/escrow', requirePolicy('mev:escrow'), async (req, res) => {
     try {
-        const { driver, amount, secret, userId } = req.body;
+        const { driver, amount, secret } = req.body;
         if (!driver || !amount || !secret) {
             return res.status(400).json({
                 success: false,
                 error: 'driver, amount, and secret required'
             });
         }
+        if (!ethers.isAddress(driver)) {
+            return res.status(400).json({
+                success: false,
+                error: 'driver must be a valid Ethereum address'
+            });
+        }
         
-        const result = await mevService.createEscrow(driver, amount, secret, userId);
+        // The caller identity comes from the authenticated session, never from
+        // the request body, so an attacker cannot create escrows on behalf of
+        // other users or attribute drain attempts to someone else.
+        const result = await mevService.createEscrow(driver, amount, secret, req.user.id);
         res.json({ success: true, data: result });
     } catch (error) {
         logger.error('Escrow creation error:', error);
@@ -44,7 +59,7 @@ router.post('/mev/escrow', async (req, res) => {
 });
 
 // Release escrow
-router.post('/mev/release/:escrowId', async (req, res) => {
+router.post('/mev/release/:escrowId', requirePolicy('mev:escrow'), async (req, res) => {
     try {
         const { escrowId } = req.params;
         const { secret, proof } = req.body;
@@ -55,7 +70,10 @@ router.post('/mev/release/:escrowId', async (req, res) => {
             });
         }
         
-        const result = await mevService.releaseEscrow(escrowId, secret, proof);
+        // `secret` alone is not an authorization mechanism: releaseEscrow
+        // verifies the caller owns the deposit (stored against the
+        // authenticated user) and that the on-chain deposit is unreleased.
+        const result = await mevService.releaseEscrow(escrowId, secret, proof, req.user);
         res.json({ success: true, data: result });
     } catch (error) {
         logger.error('Release error:', error);
@@ -64,7 +82,7 @@ router.post('/mev/release/:escrowId', async (req, res) => {
 });
 
 // Submit Flashbots bundle
-router.post('/mev/flashbots/:escrowId', async (req, res) => {
+router.post('/mev/flashbots/:escrowId', requirePolicy('mev:flashbots'), async (req, res) => {
     try {
         const { escrowId } = req.params;
         const { transactions } = req.body;


### PR DESCRIPTION
## Problem

The MEV router (`backend/mev/routes.js`) was mounted at `/api` in `backend/api/src/index.js:538` with **no authentication or authorization**. `createEscrow` funded `createProtectedDeposit(driver, secretHash, { value: ethers.parseEther(amount) })` directly from the server relayer wallet and stored `customer: this.wallet.address`. An unauthenticated attacker could supply `driver` = self and any `amount` to lock server funds into an escrow, then call `POST /api/mev/release/:escrowId` with the known `secret`. `releaseEscrow` called `releaseDepositPrivate` with **no auth and no ownership check**, releasing the funds to the attacker's `driver`. `/mev/flashbots/:escrowId` let anyone submit bundles via the relayer wallet.

## Fix

- **Authenticated the entire MEV router**: `router.use(authenticate)` in `backend/mev/routes.js` so no `/api/mev/*` endpoint is publicly reachable.
- **Authorized state-changing routes** with `requirePolicy('mev:escrow')` (create/commitment/release) and `requirePolicy('mev:flashbots')` (admin-only bundle submission). Registered both policies in `backend/api/src/security/policyEngine.js`.
- **Caller identity from session, not body**: escrows are now created against `req.user.id` instead of a caller-supplied `userId`; `driver` is validated as a real Ethereum address.
- **Ownership-checked release** in `releaseEscrow` (`backend/mev/mev.service.js`): looks up the on-chain deposit (must exist and be unreleased) and verifies the authenticated user is the escrow's creator (or an admin) via the stored `mev_escrows.user_id`. The `secret` is no longer treated as an authorization mechanism.
- **Record creator**: `storeEscrow` now persists `user_id` and a `getStoredEscrow` helper resolves ownership.

## Files changed

- `backend/api/src/security/policyEngine.js` — added `mev:escrow` and `mev:flashbots` policies.
- `backend/mev/routes.js` — added `authenticate` + `requirePolicy` to all MEV routes; session-based identity and address validation.
- `backend/mev/mev.service.js` — ownership/on-chain checks in `releaseEscrow`; persist and resolve `user_id`; reject missing auth context.

## Testing

- `node --check` passes on all three modified files.
- Existing `backend/mev/mev.service.test.js` unaffected (helper-only imports).
- Manual verification: unauthenticated `POST /api/mev/escrow` and `POST /api/mev/release/:id` now return `401` without a Bearer token; release by a non-owner returns `403 Forbidden`.

> Residual note: escrow value is still funded by the server relayer wallet. A deeper change to fund deposits from the user's own signer (server wallet as gas-only relayer) is out of scope for this targeted fix but should be tracked separately. Authentication + ownership enforcement already blocks the unauthenticated server-fund drain described in #14673.

Closes #14673
