### PR TITLE
fix(tripValidator): remove duplicate tripId declaration

### DIFF
--- a/backend/api/src/middleware/tripValidator.js
+++ b/backend/api/src/middleware/tripValidator.js
@@ -6,7 +6,6 @@ export const tripValidator = {
     if (tripId === undefined || tripId === null || tripId === '') {
       return res.status(400).json({ error: 'tripId parameter is required' });
     }
-    const tripId = req.params?.tripId;
     if (tripId !== undefined && tripId !== null) {
       if (typeof tripId !== 'string' || tripId.trim().length === 0) {
         return res.status(400).json({ error: 'Invalid tripId' });


### PR DESCRIPTION
﻿Closes #14913

## Problem
`backend/api/src/middleware/tripValidator.js`:9 declares `const tripId` a second time (line 5 already binds it), causing a parse error (`Identifier 'tripId' has already been declared`).

## Fix
Removed the duplicate declaration. Line 5 already covers both `tripId` and `id` params. Verified with `node --check` and ESLint (0 errors).

GSSOC
