### PR TITLE
fix(index): remove duplicate outboxRelayWorker import

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -167,7 +167,6 @@ import {
 } from './workers/dlqWorker.js'
 import { startStaleOrderWorker, stopStaleOrderWorker } from './workers/staleOrderWorker.js'
 import { startDevicePruningWorker, stopDevicePruningWorker } from './workers/devicePruningWorker.js'
-import { startOutboxRelayWorker, stopOutboxRelayWorker } from './workers/outboxRelayWorker.js'
 import BlockchainMetrics from './services/blockchain/blockchainMetrics.js'
 import EscalationHandler from './services/blockchain/escalationHandler.js'
 import {


### PR DESCRIPTION
﻿Closes #14914

## Problem
`backend/api/src/index.js` has two identical imports of `startOutboxRelayWorker`/`stopOutboxRelayWorker` (lines 31 and 170), a parse error that prevents the server from booting.

## Fix
Removed the duplicate import on line 170. Verified with `node --check` and ESLint (0 errors).

GSSOC
