### PR TITLE
fix(mlRoutes): remove duplicate predictEta import

### DIFF
--- a/backend/api/src/routes/mlRoutes.js
+++ b/backend/api/src/routes/mlRoutes.js
@@ -6,7 +6,6 @@ import { supabase } from '../config/db.js';
 import { authenticate } from '../middleware/auth.js';
 import { userLimiter } from '../middleware/rateLimiter.js';
 import logger from '../middleware/logger.js';
-import { predictEta } from '../services/ml.js';
 import { haversineKm } from '../lib/pricing.js';
 
 const router = express.Router();
@@ -14,18 +13,6 @@ const router = express.Router();
 function parseCoord(value, min, max) {
   const n = Number(value);
   return Number.isFinite(n) && n >= min && n <= max ? n : null;
-}
-
-// Sanitize a trip identifier before interpolating it into a PostgREST `.or()`
-// filter. The filter grammar treats `)`, `,`, quotes and whitespace as syntax,
-// so an unsanitized value could break out of the intended predicate
-// (injection / malformed query / DoS). Rejects any such characters.
-function sanitizeTripId(value) {
-  if (typeof value !== 'string') return null;
-  const trimmed = value.trim();
-  if (trimmed === '') return null;
-  if (/[,)(\s'"]/.test(trimmed)) return null;
-  return trimmed;
 }
 
 // ============================================================================
@@ -53,30 +40,6 @@ router.get(
         confidence: 0.85,
         recommended_multipliers: { base: 1.2, rush: 1.5 }
       });
-    }
-  }
-);
-
-    // Sanitize before interpolating into the PostgREST filter (see sanitizeTripId).
-    const safeTripId = sanitizeTripId(tripId);
-    if (!safeTripId) {
-      return res.status(400).json({ error: 'tripId contains invalid characters.' });
-    }
-
-    // Resolve the trip by primary key or display id, then its linked order for
-    // the drop coordinates that define the remaining route.
-    const { data: trip, error: tripErr } = await supabaseAdmin
-      .from('trips')
-      .select('id, trip_display_id, order_id')
-      .or(`id.eq.${safeTripId},trip_display_id.eq.${safeTripId}`)
-      .maybeSingle();
-
-    if (tripErr) {
-      logger.error('[MlEta] Failed to resolve trip:', tripErr);
-      return res.status(500).json({ error: 'Failed to resolve trip.' });
-    }
-    if (!trip) {
-      return res.status(404).json({ error: 'Trip not found.' });
     }
   }
 );


### PR DESCRIPTION
﻿Closes #14915

## Problem
`backend/api/src/routes/mlRoutes.js` had two issues:
- Line 9 re-imported `predictEta` already imported on line 4 (parse error).
- Lines 59-81 were an orphaned fragment of a deleted route handler (bare `return` outside a function referencing undefined `tripId`/`sanitizeTripId`/`supabaseAdmin`), leaving `sanitizeTripId` as dead code.

## Fix
Removed the duplicate import, the orphaned fragment, and the now-unused `sanitizeTripId` helper. Verified with `node --check` and ESLint (0 errors).

GSSOC
