### PR TITLE
fix(notificationService): remove duplicate hashOtp import

### DIFF
--- a/backend/api/src/services/notificationService.js
+++ b/backend/api/src/services/notificationService.js
@@ -3,7 +3,6 @@ import logger from '../middleware/logger.js';
 import crypto from 'crypto';
 import { hashOtp, verifyOtpHash } from '../lib/otpHashing.js';
 import { measureExecution } from '../core/performanceMetrics.js';
-import { hashOtp, verifyOtpHash } from '../lib/otpHashing.js';
 import { DomainError } from './order/domainError.js';
 
 // ============================================================================


### PR DESCRIPTION
﻿Closes #14916

## Problem
`backend/api/src/services/notificationService.js`:6 re-imports `hashOtp`/`verifyOtpHash` already imported on line 4 - parse error.

## Fix
Removed the duplicate import. Verified with `node --check` and ESLint (0 errors).

GSSOC
