### PR TITLE
fix(weighStationService): remove duplicate logger import

### DIFF
--- a/backend/api/src/services/weighStationService.js
+++ b/backend/api/src/services/weighStationService.js
@@ -5,8 +5,6 @@
  */
 import logger from '../middleware/logger.js';
 
-import logger from '../middleware/logger.js';
-
 const checkBypassEligibility = async (driverId, lat, lng) => {
   // No real WIM/bypass provider (Drivewyze/PrePass) is integrated. The
   // previous implementation returned a Math.random() coin-flip presented as a


### PR DESCRIPTION
﻿Closes #14917

## Problem
`backend/api/src/services/weighStationService.js`:8 re-imports `logger` already imported on line 6 - parse error.

## Fix
Removed the duplicate import. Verified with `node --check` and ESLint (0 errors).

GSSOC
