### PR TITLE
fix(OracleService): remove duplicate getStatus method

### DIFF
--- a/backend/api/src/oracle/OracleService.js
+++ b/backend/api/src/oracle/OracleService.js
@@ -252,17 +252,6 @@ class OracleService {
     }
   }
 
-  /**
-   * Returns the current oracle service status including provider count and threshold.
-   * @returns {object}
-   */
-  getStatus() {
-    return {
-      providers: 3,
-      threshold: 2,
-      timestamp: new Date().toISOString(),
-    };
-  }
 }
 
 export default OracleService;


### PR DESCRIPTION
﻿Closes #14920

## Problem
`backend/api/src/oracle/OracleService.js` defines `getStatus()` twice (lines 26 and 259); `no-dupe-class-members`. The second silently overrides the first.

## Fix
Removed the duplicate method so the documented `getStatus()` at line 26 remains. Verified with `node --check` and ESLint (0 errors).

GSSOC
