### PR TITLE
fix(EventBus): remove dead syncErrors reference

### DIFF
--- a/backend/api/src/core/events/EventBus.js
+++ b/backend/api/src/core/events/EventBus.js
@@ -158,7 +158,6 @@ class EventBus extends EventEmitter {
       } catch (err) {
         logger.error({ event, err }, '[EventBus] Sync listener error');
         this._metrics.errors++;
-        syncErrors.push(err);
       }
     }
     // Return a promise that resolves when all async listeners have settled.


### PR DESCRIPTION
﻿Closes #14921

## Problem
`backend/api/src/core/events/EventBus.js`:161 calls `syncErrors.push(err)` but `syncErrors` is never declared (no-undef); variable referenced nowhere else.

## Fix
Removed the dead line; the catch already logs and increments `this._metrics.errors`. Verified with `node --check` and ESLint (0 errors).

GSSOC
