### PR TITLE
fix(backend): use relative threshold for large-withdrawal anomaly check (#14859)

### DIFF
--- a/backend/api/src/services/security/anomalyDetectionService.js
+++ b/backend/api/src/services/security/anomalyDetectionService.js
@@ -97,16 +97,16 @@ class AnomalyDetectionService {
 
       const amount = parseFloat(transaction.amount || 0);
 
-      if (amount < ANOMALY_THRESHOLDS.LARGE_WITHDRAWAL) {
-        return null;
-      }
-
+      // The statistical z-score check must run for every withdrawal, not only
+      // those above the absolute MATIC ceiling. Gating it behind
+      // LARGE_WITHDRAWAL let fraudsters keep each withdrawal just under 1000
+      // MATIC to fully bypass the anomaly block / account lock (#14859).
       const userAvgWithdrawal = await this.getUserAverageWithdrawal(userId, walletAddress);
       const stdDev = await this.getUserWithdrawalStdDev(userId, walletAddress);
 
       const zScore = (amount - userAvgWithdrawal) / (stdDev || 1);
 
-      if (zScore > 3) {
+      if (zScore > 3 || amount >= ANOMALY_THRESHOLDS.LARGE_WITHDRAWAL) {
         return {
           type: 'LARGE_WITHDRAWAL',
           severity: 'HIGH',


### PR DESCRIPTION
## Problem

In `anomalyDetectionService.detectLargeWithdrawal`, the z-score statistical check `((amount - avg)/stddev)` only ran inside the `amount >= ANOMALY_THRESHOLDS.LARGE_WITHDRAWAL` (1000 MATIC) branch. Any withdrawal below 1000 MATIC never reached the anomaly logic, so `shouldBlockTransaction` never fired for it. A withdrawal of 999 MATIC that is a massive statistical outlier versus the user's average was silently allowed, letting fraudsters keep each withdrawal just under the fixed ceiling to fully bypass statistical anomaly blocking / account-lock.

## Fix

Compute the z-score unconditionally for every withdrawal and block on either a high z-score (`zScore > 3`) OR the absolute threshold (`amount >= LARGE_WITHDRAWAL`). This removes the early-return that gated the statistical check behind an absolute MATIC ceiling, so normal-sized but statistically anomalous withdrawals are now detected regardless of absolute size.

## Files changed

- `backend/api/src/services/security/anomalyDetectionService.js` — removed the `amount < LARGE_WITHDRAWAL` early-return; z-score is now evaluated for all withdrawals and the block condition is `zScore > 3 || amount >= ANOMALY_THRESHOLDS.LARGE_WITHDRAWAL`.

## Testing

- `node --check` on the modified service passes (syntax valid).
- Manual reasoning: a 999-MATIC withdrawal that is e.g. 50x the user's historical average now yields `zScore > 3` and returns the `LARGE_WITHDRAWAL` anomaly, which `shouldBlockTransaction` treats as blockable; previously it returned `null` immediately.

Closes #14859
