### PR TITLE
fix(backend): skip already-refunding orders in staleOrderWorker (#14861)

### DIFF
--- a/backend/api/src/workers/staleOrderWorker.js
+++ b/backend/api/src/workers/staleOrderWorker.js
@@ -182,7 +182,12 @@ async function cancelStaleOrder(staleOrder, staleSince, repository, metrics) {
 
     const order = Array.isArray(cancelled) ? cancelled[0] : cancelled;
     const orderDisplayId = order.order_display_id ?? staleOrder.order_display_id;
+    // Orders whose escrow has funds to refund (for customer messaging), but an
+    // on-chain refund must ONLY be submitted when the escrow is still 'funded'.
+    // Orders in 'refund_pending' / 'refund_failed' are already being handled by
+    // the reconciliation worker; re-submitting here would double-refund.
     const requiresRefund = ['funded', 'refund_pending', 'refund_failed'].includes(order.escrow_status ?? 'pending');
+    const canSubmitRefund = (order.escrow_status ?? 'pending') === 'funded';
 
     // Cancel associated load offers (guarded on nothing — the order is now
     // cancelled, so its offers can never be fulfilled).
@@ -194,7 +199,7 @@ async function cancelStaleOrder(staleOrder, staleSince, repository, metrics) {
     // telling the customer their funds are being returned. Only claim a refund
     // is in progress once a transaction hash is obtained.
     let refundSubmitted = false;
-    if (requiresRefund) {
+    if (canSubmitRefund) {
       try {
         const refundResult = await submitEscrowRefund(orderDisplayId);
         refundSubmitted = Boolean(refundResult && refundResult.txHash);

--- a/backend/api/test/unit/staleOrderWorkerRace.test.js
+++ b/backend/api/test/unit/staleOrderWorkerRace.test.js
@@ -158,6 +158,20 @@ describe('staleOrderWorker TOCTOU guard (issue #5741)', () => {
     expect(confirmEscrowRefund).not.toHaveBeenCalled();
   });
 
+  it('does not re-submit an on-chain refund for an order already in refund_failed', async () => {
+    orderRepository.findStalePendingOrders.mockResolvedValue({ data: [staleCandidate()], error: null });
+    orderRepository.cancelStaleOrder.mockResolvedValue({
+      data: [cancelledRow({ escrow_status: 'refund_failed' })],
+      error: null,
+    });
+
+    await reconcileStaleOrders(orderRepository);
+
+    expect(sendPushNotificationMock).toHaveBeenCalledTimes(1);
+    const { submitEscrowRefund } = await import('../../src/services/escrow.js');
+    expect(submitEscrowRefund).not.toHaveBeenCalled();
+  });
+
   it('records an error and skips side effects when the claim RPC errors', async () => {
     orderRepository.findStalePendingOrders.mockResolvedValue({ data: [staleCandidate()], error: null });
     orderRepository.cancelStaleOrder.mockResolvedValue({ data: null, error: { message: 'rpc boom' } });


### PR DESCRIPTION
## Problem

`staleOrderWorker` treated orders with `escrow_status` of `refund_pending` or `refund_failed` as needing a refund (`requiresRefund`) and unconditionally called `submitEscrowRefund`, which submits fresh on-chain `cancelBooking` + `refundFunds` transactions. For a still-`pending` order whose escrow refund is already in-flight or was previously attempted, the hourly stale sweep would re-submit the refund, producing a second on-chain refund (double refund) and losing the escrowed funds.

## Fix

In `backend/api/src/workers/staleOrderWorker.js`, separated the concern of "order has escrow funds to refund" (used for customer messaging) from "an on-chain refund may be submitted":
- `requiresRefund` still covers `funded`, `refund_pending`, `refund_failed` so the customer is correctly told a refund is in progress.
- A new `canSubmitRefund` flag is `true` only when `escrow_status === 'funded'`. The `submitEscrowRefund` call is now guarded by `canSubmitRefund`, so orders already in `refund_pending` / `refund_failed` are left to the reconciliation worker and are no longer double-refunded.

## Files changed

- `backend/api/src/workers/staleOrderWorker.js` — gate `submitEscrowRefund` behind `canSubmitRefund` (only `'funded'`), keeping `requiresRefund` for messaging.
- `backend/api/test/unit/staleOrderWorkerRace.test.js` — added a test asserting `submitEscrowRefund` is not called for an order already in `refund_failed`.

## Testing

- `node --check` on the worker and test files passes.
- Existing `staleOrderWorkerRace` test ("routes funded escrow into refund reconciliation WITHOUT submitting the refund itself") continues to assert `submitEscrowRefund` is not called for `refund_pending`.
- New test asserts `submitEscrowRefund` is not called for `refund_failed`.

Closes #14861
