### PR TITLE
fix(webhookRoutes): attach original error as cause

### DIFF
--- a/backend/api/src/routes/webhookRoutes.js
+++ b/backend/api/src/routes/webhookRoutes.js
@@ -45,7 +45,7 @@ async function isNonceReplayed(nonce) {
     } catch (err) {
       logger.error(`[Webhook] Redis nonce check failed: ${err.message}`);
       // Fail closed: if we cannot verify the nonce we must not accept the event.
-      throw new Error('Unable to verify webhook nonce');
+      throw new Error('Unable to verify webhook nonce', { cause: err });
     }
   }
 


### PR DESCRIPTION
﻿Closes #14924

## Problem
`backend/api/src/routes/webhookRoutes.js`:48 rethrows nonce-verification failure without attaching the original error (preserve-caught-error).

## Fix
Attach the cause: `throw new Error('Unable to verify webhook nonce', { cause: err });`. Verified with `node --check` and ESLint (0 errors).

GSSOC
