### PR TITLE
fix: update load_offers by verified p_order_id in update_order_and_load_offer (#14855)

### DIFF
--- a/supabase/migrations/20260802000000_secure_update_order_and_load_offer.sql
+++ b/supabase/migrations/20260802000000_secure_update_order_and_load_offer.sql
@@ -37,9 +37,10 @@ AS $$
 DECLARE
   v_updated_order JSONB;
   v_customer_id   UUID;
+  v_display_id    TEXT;
 BEGIN
   -- Resolve the owning customer of the order for the ownership guard.
-  SELECT customer_id INTO v_customer_id
+  SELECT customer_id, order_display_id INTO v_customer_id, v_display_id
   FROM orders
   WHERE id = p_order_id;
 
@@ -75,7 +76,7 @@ BEGIN
       drop_lng         = COALESCE((p_offer_updates->>'drop_lng')::NUMERIC, drop_lng),
       route_label      = COALESCE(p_offer_updates->>'route_label', route_label),
       extra_distance_km = COALESCE((p_offer_updates->>'extra_distance_km')::NUMERIC, extra_distance_km)
-    WHERE order_display_id = p_order_display_id;
+    WHERE order_display_id = v_display_id;
   ELSE
     UPDATE orders
     SET
@@ -101,7 +102,7 @@ BEGIN
       toll_cost         = COALESCE((p_offer_updates->>'toll_cost')::NUMERIC, toll_cost),
       net_profit        = COALESCE((p_offer_updates->>'net_profit')::NUMERIC, net_profit),
       extra_distance_km = COALESCE((p_offer_updates->>'extra_distance_km')::NUMERIC, extra_distance_km)
-    WHERE order_display_id = p_order_display_id;
+    WHERE order_display_id = v_display_id;
   END IF;
 
   RETURN v_updated_order;


### PR DESCRIPTION
## Problem

In `update_order_and_load_offer`, the ownership guard `get_profile_id() <> v_customer_id` is checked only against the verified `p_order_id`. However, both `UPDATE load_offers` statements filter on `WHERE order_display_id = p_order_display_id`, where `p_order_display_id` is a separate, caller-supplied argument that is never proven to belong to the verified order. An authenticated customer could pass their own valid `p_order_id` together with a victim's `p_order_display_id` and rewrite that victim's `load_offers` destination fields (drop_address, drop_lat, drop_lng, route_label, extra_distance_km) — an IDOR / broken object-level authorization (Issue #14855).

## Fix

Derive the display id from the verified `p_order_id` instead of trusting the client-supplied `p_order_display_id`:
- `SELECT customer_id, order_display_id INTO v_customer_id, v_display_id FROM orders WHERE id = p_order_id;`
- Both `UPDATE load_offers` statements now use `WHERE order_display_id = v_display_id`.

This guarantees the mutated `load_offers` row belongs to the same order the caller is authorized for. The `p_order_display_id` parameter is retained for signature compatibility but is no longer used to target rows.

## Files changed

- `supabase/migrations/20260802000000_secure_update_order_and_load_offer.sql`

## Testing

- Confirmed via grep that no `UPDATE load_offers` references the unverified `p_order_display_id`; both now filter by the verified `v_display_id`.
- SQL is syntactically consistent with the existing function body (DECLARE, SELECT INTO, WHERE clauses).

Closes #14855
