### PR TITLE
fix: reject negative/non-numeric amount in validateCreateOrder (#14858)

### DIFF
--- a/backend/eventsourcing/event-store.js
+++ b/backend/eventsourcing/event-store.js
@@ -240,7 +240,8 @@ class EventStore {
 
     validateCreateOrder(payload) {
         if (!payload.customerId) return { valid: false, error: 'customerId required' };
-        if (!payload.amount) return { valid: false, error: 'amount required' };
+        if (typeof payload.amount !== 'number' || !Number.isFinite(payload.amount) || payload.amount <= 0)
+            return { valid: false, error: 'amount must be a positive finite number' };
         if (!payload.pickup) return { valid: false, error: 'pickup location required' };
         if (!payload.dropoff) return { valid: false, error: 'dropoff location required' };
         return { valid: true };


### PR DESCRIPTION
## Problem

`validateCreateOrder` in the eventsourcing command validator only checked `if (!payload.amount)`, so a negative (`-100`) or non-numeric (`"abc"`, `NaN`, `Infinity`) amount passed validation. Such an amount flows through the read model into `complete_trip_tx`, which executes `wallet_confirmed = wallet_confirmed + COALESCE(bid_amount, total_amount)`. A negative amount therefore *subtracts* from the driver's confirmed balance — effectively debiting (rather than crediting) the driver's wallet.

## Fix

Tightened the `amount` validation in `validateCreateOrder` to require a finite positive number:

```js
if (typeof payload.amount !== 'number' || !Number.isFinite(payload.amount) || payload.amount <= 0)
    return { valid: false, error: 'amount must be a positive finite number' };
```

This rejects negative, `NaN`, `Infinity`, non-numeric, and zero amounts at validation time, before they can ever reach the wallet ledger.

## Files changed

- `backend/eventsourcing/event-store.js` — `validateCreateOrder` amount check.

## Testing

- `node --check backend/eventsourcing/event-store.js` passes.
- Logic review: negative, `NaN`, `Infinity`, string, `0`, and `undefined` amounts now return `{ valid: false }`; only finite positive numbers are accepted.

Closes #14858
