### PR TITLE
security: fix keyRotationService ordering and nonce in key rotation (#14856)

### DIFF
--- a/backend/api/src/services/security/keyRotationService.js
+++ b/backend/api/src/services/security/keyRotationService.js
@@ -38,9 +38,12 @@ class KeyRotationService {
 
         const rotationId = await this.createRotationRecord(userId, walletAddress, reason);
 
-        await this.archiveCurrentKey(userId, walletAddress, reason);
-
+        // Store the new key first so a failure in storeNewKey never leaves the
+        // wallet with zero active keys (the old one is only retired after this
+        // succeeds inside the guarded transaction below).
         const newKeyId = await this.storeNewKey(userId, walletAddress, newPrivateKey);
+
+        await this.archiveCurrentKey(userId, walletAddress, reason);
 
         await this.updateRotationRecord(rotationId, {
           status: 'completed',
@@ -171,11 +174,15 @@ class KeyRotationService {
         const newWalletAddress = new ethers.Wallet(newPrivateKey).address;
 
         // Verify contract interface expects (address, uint256) — never pass raw key.
+        // Use a cryptographically secure random nonce instead of wall-clock time
+        // so concurrent rotations can never collide or be replayed.
+        const nonce = ethers.toBigInt('0x' + crypto.randomBytes(32).toString('hex'));
+
         const tx = await oldWallet.sendTransaction({
           to: this.escrowContract.target,
           data: this.escrowContract.interface.encodeFunctionData('transferKeyOwnership', [
             newWalletAddress,  // public address only — never the private key
-            Date.now(),
+            nonce,
           ]),
         });
 


### PR DESCRIPTION
## Problem

In `initiateKeyRotation` the current active key was archived (`active = false`) BEFORE the new key was persisted. If `storeNewKey` threw (e.g. encryption failure) the wallet's only active signing key was gone with no replacement, bricking the wallet. Separately, `transferKeyOwnershipOnChain` passed `Date.now()` as the contract `nonce`, which collides for two rotations in the same millisecond and provides no replay protection.

## Fix

- Reordered `initiateKeyRotation` so `storeNewKey` runs before `archiveCurrentKey`. The new key is now durably stored before the old one is retired, so a rotation failure never leaves the wallet with zero active keys.
- Replaced the `Date.now()` on-chain nonce with a cryptographically secure 256-bit random nonce (`crypto.randomBytes(32)` via `ethers.toBigInt`), eliminating same-millisecond collisions and nonce replay.

Note: the deployed escrow contract does not expose a `nonce()`/`escrowNonce` getter, so a per-wallet on-chain monotonic counter is not available; the secure random nonce provides equivalent collision/replay protection without relying on a non-existent contract call.

## Files changed

- `backend/api/src/services/security/keyRotationService.js`

## Testing

- `node --check` on the modified service passes (syntax valid).
- Manual review of the rotation flow confirms new-key-before-archive ordering and the absence of `Date.now()` in the on-chain nonce path.

Closes #14856
