### PR TITLE
fix(index): import sentryRequestHandler and captureException

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -144,7 +144,7 @@ import { correlationIdMiddleware } from './middleware/correlationId.js'
 import { requestCacheMiddleware } from './middleware/requestCacheMiddleware.js'
 import { requireJsonContent } from './middleware/contentType.js'
 import { verifyJWT } from './middleware/auth.js'
-import { initSentry, flushSentry, sentryErrorHandler } from './middleware/sentry.js'
+import { initSentry, flushSentry, sentryErrorHandler, sentryRequestHandler, captureException } from './middleware/sentry.js'
 import {
   startEscrowRefundReconciliation,
   stopEscrowRefundReconciliation


### PR DESCRIPTION
Closes #14960

## Problem
`backend/api/src/index.js` uses `sentryRequestHandler()` (line 335) and `captureException(reason)` (line 869) but neither is imported from `./middleware/sentry.js`, causing two `no-undef` errors.

## Fix
Added `sentryRequestHandler` and `captureException` to the existing Sentry import.

GSSOC
