### PR TITLE
fix(documentController): remove duplicate extension declaration

### DIFF
--- a/backend/api/src/controllers/documentController.js
+++ b/backend/api/src/controllers/documentController.js
@@ -145,12 +145,8 @@ export async function uploadDriverDocument(req, res) {
       });
     }
 
-    const extension = verifiedMimeType === 'application/pdf' ? 'pdf'
-      : verifiedMimeType === 'image/png' ? 'png'
-      : 'jpg';
-
     // Appended randomUUID() to guarantee uniqueness even during rapid concurrent uploads
-    const storagePath = `${driverId}/${documentType}-${Date.now()}-${randomUUID()}.${extension}`;
+    const storagePath = `${driverId}/${documentType}-${Date.now()}-${crypto.randomUUID()}.${extension}`;
 
     const { error: storageError } = await client.storage
       .from('driver-documents')


### PR DESCRIPTION
Closes #14963

## Problem
`backend/api/src/controllers/documentController.js` declared `const extension` twice (lines 141 and 148-150) — a parse error. The map-based lookup at line 141 already resolves the extension; the ternary duplicate was dead code. The storage path also called bare `randomUUID()` which is never imported.

## Fix
- Removed the duplicate `const extension` block at lines 148-150.
- Changed `randomUUID()` to `crypto.randomUUID()` (crypto is already imported).

GSSOC
