### PR TITLE
fix(maintenancePhotoController): remove mangled duplicate upload block

### DIFF
--- a/backend/api/src/controllers/maintenancePhotoController.js
+++ b/backend/api/src/controllers/maintenancePhotoController.js
@@ -130,30 +130,8 @@ export async function uploadMaintenancePhotos(req, res) {
             throw errObj;
           }
           throw scanError;
-        }
-        throw scanError;
       }
-
       const ext = extensionForMime(verifiedMimeType);
-      const storagePath = `${driverId}/${ticketId}/${Date.now()}-${randomUUID()}.${ext}`;
-
-      const { error: storageError } = await supabase.storage
-        .from('maintenance-photos')
-        .upload(storagePath, file.buffer, {
-          contentType: verifiedMimeType,
-          upsert: false,
-        });
-
-      if (storageError) {
-        logger.error('[MaintenancePhotoController] Storage upload failed:', storageError.message);
-        await cleanupStorage(uploadedPaths);
-        return res.status(500).json({ error: 'Failed to store photo' });
-      }
-
-      uploadedPaths.push(storagePath);
-    }
-
-        const ext = extensionForMime(verifiedMimeType);
         const storagePath = `${driverId}/${ticketId}/${Date.now()}-${randomUUID()}.${ext}`;
 
         const { error: storageError } = await supabase.storage
@@ -211,21 +189,6 @@ export async function uploadMaintenancePhotos(req, res) {
       }
 
       return res.status(500).json({ error: 'Failed to save photo references' });
-    }
-
-    // Generate signed URLs for ALL paths (both pre-existing and newly uploaded)
-    const allSignedUrls = [];
-    for (const path of allPaths) {
-      const { data: urlData, error: urlError } = await supabase.storage
-        .from('maintenance-photos')
-        .createSignedUrl(path, 60 * 60 * 24 * 7); // 7-day expiry
-
-      if (urlError) {
-        logger.error('[MaintenancePhotoController] Failed to create signed URL:', urlError.message);
-        return res.status(500).json({ error: 'Failed to generate photo URL' });
-      }
-
-      allSignedUrls.push(urlData.signedUrl);
     }
 
     return res.status(200).json({


### PR DESCRIPTION
Closes #14964

## Problem
`backend/api/src/controllers/maintenancePhotoController.js` was mangled by a bad merge. Inside the upload `Promise.all(...map(...))` callback:
- line 134 re-threw `scanError` outside its try/catch, so every upload threw and the callback closed early;
- lines 137-154 were a duplicated upload block (block A) inserted mid-callback;
- lines 156-175 were the original block (block B, the correct `return storagePath` version), orphaned outside the callback.

Additionally, a later block (lines 194-207) looped over an undefined `allPaths` variable, producing a second `no-undef` error and dead code.

Result: parse error (`Unexpected token const`) and guaranteed upload failure.

## Fix
- Removed the spurious `throw scanError;`, the premature callback close, and duplicated block A, leaving block B as the single upload path.
- Removed the dead `allPaths` signed-URL block; the response uses the existing `photoUrls` (line 209).
Verified with `node --check` and ESLint (0 errors).

GSSOC
