### PR TITLE
fix(deliveryRoutes): deduplicate notificationService import

### DIFF
--- a/backend/api/src/routes/deliveryRoutes.js
+++ b/backend/api/src/routes/deliveryRoutes.js
@@ -4,8 +4,7 @@ import { authenticate } from '../middleware/auth.js';
 import { userLimiter } from '../middleware/rateLimiter.js';
 import { validateBody } from '../middleware/validate.js';
 import { orderRepository, orderLifecycleService, logger } from '../core/container.js';
-import { sendFcmNotification } from '../services/notificationService.js';
-import { storeDeliveryOtp } from '../services/notificationService.js';
+import { sendFcmNotification, storeDeliveryOtp } from '../services/notificationService.js';
 import crypto from 'crypto';
 
 const router = express.Router();


### PR DESCRIPTION
Closes #14965

## Problem
`backend/api/src/routes/deliveryRoutes.js` imports `../services/notificationService.js` twice (lines 6 and 8) — ESLint `no-duplicate-imports`.

## Fix
Removed the duplicate import.

GSSOC
