### PR TITLE
fix(outboxService): destructure data in markPublished

### DIFF
--- a/backend/api/src/services/outbox/outboxService.js
+++ b/backend/api/src/services/outbox/outboxService.js
@@ -86,7 +86,7 @@ export class OutboxService {
    * 'pending' so any replica can reclaim them.
    */
   async markPublished(eventId) {
-    const { error } = await supabaseAdmin
+    const { data, error } = await supabaseAdmin
       .from('event_outbox')
       .update({ status: 'published', published_at: new Date().toISOString() })
       .eq('event_id', eventId);


### PR DESCRIPTION
Closes #14966

## Problem
`backend/api/src/services/outbox/outboxService.js` `markPublished()` destructures only `{ error }` from the supabase update but returns `Boolean(data && data.length > 0)` on line 97, where `data` is undefined — ESLint `no-undef`.

## Fix
Destructured `data` alongside `error`.

GSSOC
