### PR TITLE
fix(test): remove duplicate vitest import in orderRoutesGeofence test

### DIFF
--- a/backend/api/test/unit/orderRoutesGeofence.test.js
+++ b/backend/api/test/unit/orderRoutesGeofence.test.js
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi } from 'vitest';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import express from 'express';
 import request from 'supertest';
@@ -64,27 +63,6 @@ import { orderValidationService, orderLifecycleService } from '../../src/core/co
 
 const app = express();
 app.use(express.json());
-app.use('/api/orders', orderRoutes);
-
-describe('POST /api/orders/:id/geofence-confirm validation', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    findOrderByIdOrDisplayIdMock.mockReset();
-    assertDriverAssignmentMock.mockReset();
-    geofenceAutoConfirmMock.mockReset();
-  });
-
-  it('should accept valid lat, lng and geofence_radius_m', async () => {
-    findOrderByIdOrDisplayIdMock.mockResolvedValue({
-      id: '123',
-      driver_id: DRIVER_HEADERS['x-user-id'],
-      customer_id: 'customer-1'
-    });
-    geofenceAutoConfirmMock.mockResolvedValue({ success: true });
-app.use((req, res, next) => {
-  req.user = { id: 'driver-1' };
-  next();
-});
 app.use('/api/orders', orderRoutes);
 
 describe('POST /api/orders/:id/geofence-confirm validation', () => {


### PR DESCRIPTION
Closes #14968

## Problem
`backend/api/test/unit/orderRoutesGeofence.test.js` was broken by a bad merge:
- Two `import ... from 'vitest'` statements (lines 1-2) with overlapping bindings — parse error (`Identifier 'describe' has already been declared`).
- A duplicated `describe('POST /api/orders/:id/geofence-confirm validation', ...)` block plus a stray `app.use(...)` fragment were inserted inside the first `it(...)` body, leaving the file with unbalanced blocks — `SyntaxError: Unexpected end of input`. The test could not parse, so it never ran.

## Fix
- Removed the duplicate vitest import.
- Removed the stray `app.use(...)` fragment and the duplicated `describe` block, keeping the single well-formed validation describe block followed by the existing #12053 regression describe block.
Verified with `node --check` and ESLint (0 errors).

GSSOC
