### PR TITLE
fix(test): remove duplicate matchesMimeSignature import in documentValidation test

### DIFF
--- a/backend/api/test/unit/documentValidation.test.js
+++ b/backend/api/test/unit/documentValidation.test.js
@@ -5,7 +5,6 @@ import {
   matchesMimeSignature,
   DocumentValidationError,
   ALLOWED_DOCUMENT_MIME_TYPES,
-  matchesMimeSignature,
 } from '../../src/lib/documentValidation.js';
 
 describe('documentValidation', () => {


### PR DESCRIPTION
Closes #14969

## Problem
`backend/api/test/unit/documentValidation.test.js` imports `matchesMimeSignature` twice from `../../src/lib/documentValidation.js` (lines 5 and 7) — ESLint `no-duplicate-imports` and a parse error.

## Fix
Removed the duplicate `matchesMimeSignature,` entry from the import list.

GSSOC
