### PR TITLE
fix(test): import parseDisplayId in orderDisplayId test

### DIFF
--- a/backend/api/test/unit/orderDisplayId.test.js
+++ b/backend/api/test/unit/orderDisplayId.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { generateOrderDisplayId, validateOrderDisplayId } from '../../../src/lib/orderDisplayId.js';
+import { generateOrderDisplayId, validateOrderDisplayId, parseDisplayId } from '../../../src/lib/orderDisplayId.js';
 
 describe('orderDisplayId.js', () => {
   describe('generateOrderDisplayId', () => {


### PR DESCRIPTION
Closes #14970

## Problem
`backend/api/test/unit/orderDisplayId.test.js` uses `parseDisplayId()` (line 43) but the import only pulls in `generateOrderDisplayId, validateOrderDisplayId` — ESLint `no-undef`.

## Fix
Added `parseDisplayId` to the import from `../../../src/lib/orderDisplayId.js`.

GSSOC
