### PR TITLE
fix(maintenancePhoto): repair mangled upload loop from bad merge (#14876)

### DIFF
--- a/backend/api/src/controllers/maintenancePhotoController.js
+++ b/backend/api/src/controllers/maintenancePhotoController.js
@@ -131,27 +131,6 @@ export async function uploadMaintenancePhotos(req, res) {
           }
           throw scanError;
         }
-        throw scanError;
-      }
-
-      const ext = extensionForMime(verifiedMimeType);
-      const storagePath = `${driverId}/${ticketId}/${Date.now()}-${randomUUID()}.${ext}`;
-
-      const { error: storageError } = await supabase.storage
-        .from('maintenance-photos')
-        .upload(storagePath, file.buffer, {
-          contentType: verifiedMimeType,
-          upsert: false,
-        });
-
-      if (storageError) {
-        logger.error('[MaintenancePhotoController] Storage upload failed:', storageError.message);
-        await cleanupStorage(uploadedPaths);
-        return res.status(500).json({ error: 'Failed to store photo' });
-      }
-
-      uploadedPaths.push(storagePath);
-    }
 
         const ext = extensionForMime(verifiedMimeType);
         const storagePath = `${driverId}/${ticketId}/${Date.now()}-${randomUUID()}.${ext}`;
@@ -211,21 +190,6 @@ export async function uploadMaintenancePhotos(req, res) {
       }
 
       return res.status(500).json({ error: 'Failed to save photo references' });
-    }
-
-    // Generate signed URLs for ALL paths (both pre-existing and newly uploaded)
-    const allSignedUrls = [];
-    for (const path of allPaths) {
-      const { data: urlData, error: urlError } = await supabase.storage
-        .from('maintenance-photos')
-        .createSignedUrl(path, 60 * 60 * 24 * 7); // 7-day expiry
-
-      if (urlError) {
-        logger.error('[MaintenancePhotoController] Failed to create signed URL:', urlError.message);
-        return res.status(500).json({ error: 'Failed to generate photo URL' });
-      }
-
-      allSignedUrls.push(urlData.signedUrl);
     }
 
     return res.status(200).json({

--- a/backend/api/test/unit/maintenancePhotoController.mangledMerge.test.js
+++ b/backend/api/test/unit/maintenancePhotoController.mangledMerge.test.js
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Regression for #14876: a bad merge mangled maintenancePhotoController.js so
+// the photo-upload loop body was duplicated, a `throw scanError;` was stranded
+// outside its catch, and a later `for (const path of allPaths)` referenced an
+// undefined `allPaths`. The result was a SyntaxError (`missing ) after argument
+// list` / duplicate declarations) so the module could not be imported at all,
+// which also broke `maintenancePhotoRoutes` (it statically imports the router
+// which imports this controller).
+//
+// This test imports the real controller module. On the broken revision the
+// dynamic import rejects with a SyntaxError; after the fix it resolves and the
+// happy path returns 200 with uploaded_count/photo_urls.
+
+vi.mock('../../src/config/db.js', () => {
+  const storageObjects = [];
+  const storage = {
+    from(bucket) {
+      return {
+        upload(path, buffer, options) {
+          storageObjects.push({ bucket, path, buffer, options });
+          return Promise.resolve({ data: { path }, error: null });
+        },
+        async createSignedUrl(path, expiresIn) {
+          return {
+            data: { signedUrl: `https://mock-storage.example/${bucket}/${path}?expires=${expiresIn}` },
+            error: null,
+          };
+        },
+        async remove(paths) {
+          for (const p of paths) {
+            const idx = storageObjects.findIndex((o) => o.path === p);
+            if (idx >= 0) storageObjects.splice(idx, 1);
+          }
+        },
+      };
+    },
+    storage: { /* set below after from() closure is wired */ },
+  };
+  // `supabase.storage` must be the same object the controller reaches; the
+  // controller calls `supabase.storage.from('maintenance-photos')`, so expose a
+  // `.storage` whose `from` returns the same chain.
+  const supabase = { storage: { from: storage.from.bind(storage) } };
+
+  // userClient mirrors the subset the controller uses: from().select().eq().maybeSingle()
+  // and .rpc().
+  let ticketStore = [];
+  const userClient = {
+    from(table) {
+      if (table === 'truck_maintenance_tickets') {
+        return {
+          select() {
+            return this;
+          },
+          eq(_col, _val) {
+            return this;
+          },
+          maybeSingle() {
+            return Promise.resolve({ data: ticketStore[0] ?? null, error: null });
+          },
+        };
+      }
+      return {
+        select() {
+          return this;
+        },
+        eq() {
+          return this;
+        },
+        maybeSingle() {
+          return Promise.resolve({ data: null, error: null });
+        },
+      };
+    },
+    rpc(_name, _args) {
+      return Promise.resolve({ data: null, error: null });
+    },
+  };
+
+  return {
+    supabase,
+    createUserClient: () => userClient,
+    firebaseAdmin: null,
+    redisClient: null,
+    mongoDb: null,
+    __setTicketStore(rows) {
+      ticketStore = rows;
+    },
+    __storageObjects: storageObjects,
+  };
+});
+
+vi.mock('../../src/middleware/logger.js', () => ({
+  default: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('../../src/lib/malwareScanner.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    scanDocument: vi.fn().mockResolvedValue({ clean: true, engine: 'mock' }),
+  };
+});
+
+// validateDocumentBuffer is a pure function (magic-byte sniff). Let it run for
+// real so the JPEG/PNG happy path is exercised end-to-end.
+
+const { uploadMaintenancePhotos } = await import('../../src/controllers/maintenancePhotoController.js');
+const dbMock = await import('../../src/config/db.js');
+
+const JPEG_BYTES = Buffer.from([
+  0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x46, 0x49,
+]);
+
+function fakeRes() {
+  const sent = {};
+  const res = {
+    status(code) {
+      sent.code = code;
+      return this;
+    },
+    json(body) {
+      sent.body = body;
+      return this;
+    },
+  };
+  return { res, sent };
+}
+
+describe('maintenancePhotoController — bad-merge regression (#14876)', () => {
+  beforeEach(() => {
+    dbMock.__setTicketStore([
+      {
+        id: 'ticket-1',
+        driver_id: 'driver-1',
+        photo_urls: [],
+      },
+    ]);
+    dbMock.__storageObjects.length = 0;
+  });
+
+  it('module imports without SyntaxError (regression: duplicate upload block stranded throw)', async () => {
+    expect(typeof uploadMaintenancePhotos).toBe('function');
+  });
+
+  it('uploads a JPEG and returns 200 with photo_urls + uploaded_count (regression: allPaths ReferenceError)', async () => {
+    const { res, sent } = fakeRes();
+    await uploadMaintenancePhotos(
+      {
+        user: { id: 'driver-1' },
+        token: 'jwt-token',
+        params: { ticketId: 'ticket-1' },
+        files: [{ buffer: JPEG_BYTES, mimetype: 'image/jpeg' }],
+      },
+      res,
+    );
+
+    expect(sent.code).toBe(200);
+    expect(sent.body.success).toBe(true);
+    expect(sent.body.uploaded_count).toBe(1);
+    expect(sent.body.photo_urls).toHaveLength(1);
+    expect(dbMock.__storageObjects.length).toBe(1);
+    expect(dbMock.__storageObjects[0].bucket).toBe('maintenance-photos');
+  });
+});


### PR DESCRIPTION
Closes #14876.

## Problem

`backend/api/src/controllers/maintenancePhotoController.js` was mangled by a bad merge. The per-file upload body inside the `Promise.all(uploadedFiles.map(...))` callback appeared **twice**, a `throw scanError;` was **stranded outside its catch** block, and a later `for (const path of allPaths)` iterated an **undefined** `allPaths`. The duplicate declarations produced a `SyntaxError` so the module could not be imported — verified with `node --check` on `main`:

```
SyntaxError: missing ) after argument list (line 135)
```

Because `maintenancePhotoRoutes` statically imports the router which imports this controller, `POST /api/maintenance/:ticketId/photos` is dead and the whole maintenance-photo feature is offline.

## Fix

- Collapse the upload map callback to a single body: validate MIME -> malware-scan -> upload -> push `storagePath` -> `return storagePath`. Storage failures now `throw` an `errObj` with `statusCode = 500` (caught by the outer `catch` for cleanup + status mapping) instead of the dedented `return res.status(500)` that lived outside the `Promise.all` map.
- Remove the dead `allSignedUrls`/`allPaths` block: `allPaths` was never defined (`ReferenceError` at runtime) and `allSignedUrls` was never used — the response already returns `[...existingUrls, ...photoUrls]`.

## Regression test

New: `test/unit/maintenancePhotoController.mangledMerge.test.js` (2 cases).

1. **Module imports without SyntaxError** — `await import('../../src/controllers/maintenancePhotoController.js')` resolves. On the broken revision this fails to transform (SyntaxError), so the test file cannot even load.
2. **JPEG happy path returns 200** with `success`, `uploaded_count === 1`, `photo_urls.length === 1`, and one object recorded in the `maintenance-photos` storage bucket. This exercises the upload map end-to-end and would throw the `allPaths` `ReferenceError` if that block remained.

TDD-verified: both tests **fail on `main`** (file fails to load) and **pass with this fix**. `node --check` passes on the controller.

## Scope note

`allPaths`/`allSignedUrls` was a second dead-and-broken leftover from the same bad merge described in #14876. It is removed here as part of repairing the mangled controller so the endpoint actually works (not as a separate concern).

Note: this PR was created by an AI agent (OpenHands) on behalf of saidai-bhuvanesh.

Closes #14876.