### PR TITLE
fix(orderCreationService): remove duplicate `let pricing` block (#14875)

### DIFF
--- a/backend/api/src/services/order/orderCreationService.js
+++ b/backend/api/src/services/order/orderCreationService.js
@@ -163,36 +163,6 @@ export async function createOrder({ orderData, userId, user, idempotencyKey = nu
     });
   }
 
-    if (!pickup_address || pickup_lat == null || pickup_lng == null || !drop_address || drop_lat == null || drop_lng == null || !goods_type || weight_tonnes == null) {
-      throw new DomainError(400, { error: 'Missing required routing or cargo specification fields.' });
-    }
-
-    let pricing;
-    try {
-      const routeEstimate = await getRouteEstimate({
-        pickupLat: Number(pickup_lat),
-        pickupLng: Number(pickup_lng),
-        dropLat: Number(drop_lat),
-        dropLng: Number(drop_lng),
-      });
-      pricing = computeOrderPricing({
-        pickupLat: Number(pickup_lat),
-        pickupLng: Number(pickup_lng),
-        dropLat: Number(drop_lat),
-        dropLng: Number(drop_lng),
-        weightTonnes: Number(weight_tonnes),
-        roadDistanceKm: routeEstimate?.distanceKm,
-        isFragile: Boolean(is_fragile),
-        isStackable: Boolean(is_stackable),
-      });
-    } catch (pricingErr) {
-      logger.error('Pricing computation error:', pricingErr.message);
-      throw new DomainError(400, {
-        error: 'Unable to compute freight pricing for the given route/cargo.',
-        details: pricingErr.message,
-      });
-    }
-
     let estimatedPrice = null;
     try {
       const trafficMultiplier = await getLiveTrafficMultiplier(pickup_lat, pickup_lng);

--- a/backend/api/test/unit/orderCreationService.duplicatePricing.test.js
+++ b/backend/api/test/unit/orderCreationService.duplicatePricing.test.js
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+
+// Regression for #14875: orderCreationService.js declared `let pricing;` twice
+// in the same scope (a stale merge leftover re-implemented the pricing block),
+// so the module failed to evaluate with `SyntaxError: Identifier 'pricing' has
+// already been declared`. `orderRoutes.js:159` statically imports
+// `createOrder` from this module, so the failed load also broke every order
+// route. This test imports the real module; on the broken revision the dynamic
+// import rejects with a SyntaxError, on the fixed revision it resolves.
+
+const mod = await import('../../src/services/order/orderCreationService.js');
+
+describe('orderCreationService — duplicate `let pricing` regression (#14875)', () => {
+  it('module imports without SyntaxError (duplicate pricing declaration removed)', () => {
+    expect(typeof mod.createOrder).toBe('function');
+  });
+
+  it('declares `pricing` exactly once (no duplicate let)', async () => {
+    const fs = await import('node:fs');
+    const src = fs.readFileSync(
+      new URL('../../src/services/order/orderCreationService.js', import.meta.url),
+      'utf8',
+    );
+    // The canonical pricing block remains; the stale merge-leftover that
+    // re-declared `let pricing;` is gone.
+    const pricingDecls = (src.match(/^\s*let pricing;\s*$/gm) || []);
+    expect(pricingDecls.length).toBe(1);
+  });
+});


### PR DESCRIPTION
Closes #14875.

## Problem

`backend/api/src/services/order/orderCreationService.js` declared `let pricing;` **twice in the same scope** (lines 140 and 170). A bad merge left a second, redundant pricing block — an `if (!pickup_address ...)` guard + `let pricing;` + a duplicate route-estimate/pricing try/catch — that re-implemented the pre-existing validated pricing flow above it. The duplicate declaration made the module fail to evaluate:

```
SyntaxError: Identifier 'pricing' has already been declared
```

`orderRoutes.js:159` statically imports `createOrder` from this module, so the failed load also broke every order route.

## Fix

Remove the stale merge-leftover pricing block (the second `if (!pickup_address ...)` + `let pricing;` + try/catch), keeping the single validated pricing flow at the original location. `pricing` is now declared exactly once. Behavior of the canonical flow is unchanged.

Verified with `node --check backend/api/src/services/order/orderCreationService.js` → exit 0.

## Regression test

New: `test/unit/orderCreationService.duplicatePricing.test.js` (2 cases).

1. **Module imports without SyntaxError** — `await import('../../src/services/order/orderCreationService.js')` resolves and `createOrder` is a function. On the broken revision this rejects with `SyntaxError: Identifier 'pricing' has already been declared`, so the test file cannot even load.
2. **`let pricing;` appears exactly once** — a source scan guards against the duplicate declaration regressing.

TDD-verified: both tests **fail on `main`** (file fails to load with the SyntaxError) and **pass with this fix**.

## Scope

This PR is scoped strictly to #14875 (the duplicate `let pricing` SyntaxError in `orderCreationService.js`). The independent load-breakers in `orderRoutes.js` mentioned in the issue (#14790 duplicate `createOrder` import, #14818 double `export default router`) are tracked separately and addressed in their own PRs.

Note: this PR was created by an AI agent (OpenHands) on behalf of saidai-bhuvanesh.

Closes #14875.