### PR TITLE
fix(ratings): recompute driver average AFTER DELETE on ratings (#14938)

### DIFF
--- a/backend/api/test/unit/ratingsDeleteRecompute.test.js
+++ b/backend/api/test/unit/ratingsDeleteRecompute.test.js
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Regression for #14938: submit_rating_tx recomputes driver_details.rating on
+// INSERT/UPDATE only, but the "Customers manage own ratings" RLS policy is
+// FOR ALL (permits DELETE via its USING clause) and there was no AFTER DELETE
+// trigger. So deleting a rating left the stored driver average permanently
+// stale. This test asserts the AFTER DELETE recompute migration is present and
+// wired to refresh driver_details.rating from AVG(stars) over the surviving
+// rows — mirroring the repo's established migration-regression pattern
+// (ratingsRlsRegression.test.js).
+describe('ratings AFTER DELETE recomputes driver average (#14938)', () => {
+  const sql = readFileSync(
+    path.resolve(
+      __dirname,
+      '../../../../supabase/migrations/20260815000000_ratings_after_delete_recompute.sql'
+    ),
+    'utf8'
+  );
+
+  it('defines a trigger function that recomputes AVG(stars) for the deleted row driver', () => {
+    expect(sql).toMatch(/CREATE OR REPLACE FUNCTION\s+recompute_driver_rating_after_rating_delete\(\)/i);
+    // recompute from the surviving ratings for OLD.driver_id (NOT the deleted row)
+    expect(sql).toMatch(/FROM\s+ratings\s+WHERE\s+driver_id\s*=\s*OLD\.driver_id/i);
+    expect(sql).toMatch(/ROUND\s*\(\s*AVG\s*\(\s*stars\s*\)/i);
+    // write the recomputed average back to driver_details for that driver
+    expect(sql).toMatch(/UPDATE\s+driver_details\s+SET\s+rating\s*=\s*v_new_avg/i);
+    expect(sql).toMatch(/user_id\s*=\s*OLD\.driver_id/i);
+  });
+
+  it('wires the function to an AFTER DELETE FOR EACH ROW trigger on ratings', () => {
+    expect(sql).toMatch(/DROP TRIGGER IF EXISTS\s+trg_ratings_after_delete_recompute\s+ON\s+public\.ratings/i);
+    expect(sql).toMatch(/CREATE TRIGGER\s+trg_ratings_after_delete_recompute\s+AFTER DELETE\s+ON\s+public\.ratings\s+FOR EACH ROW\s+EXECUTE (?:FUNCTION|PROCEDURE)\s+recompute_driver_rating_after_rating_delete\(\)/i);
+  });
+
+  it('is idempotent (drops the trigger before creating it)', () => {
+    expect(sql).toMatch(/DROP TRIGGER IF EXISTS\s+trg_ratings_after_delete_recompute/i);
+  });
+});

--- a/supabase/migrations/20260815000000_ratings_after_delete_recompute.sql
+++ b/supabase/migrations/20260815000000_ratings_after_delete_recompute.sql
@@ -1,0 +1,59 @@
+-- =============================================================================
+-- Migration: Recompute driver average rating AFTER DELETE on ratings (#14938)
+-- =============================================================================
+-- Problem:
+--   submit_rating_tx recomputes driver_details.rating = ROUND(AVG(stars)) only
+--   on INSERT/UPDATE. The "Customers manage own ratings" RLS policy is
+--   FOR ALL (permits DELETE via its USING clause), but there is no AFTER
+--   DELETE trigger. So once a customer deletes their own rating, the stored
+--   driver_details.rating is never refreshed and no longer equals AVG(stars)
+--   over the remaining rows — the driver's displayed rating is permanently
+--   wrong and reachable via PostgREST.
+--
+-- Solution:
+--   Add an AFTER DELETE trigger that recomputes the affected driver's average
+--   from the surviving ratings, mirroring the INSERT/UPDATE path in
+--   submit_rating_tx. When the last rating is deleted, AVG() over an empty set
+--   is NULL, so the driver's rating is set back to NULL (matching the column's
+--   pre-rating state).
+--
+-- Idempotent: DROP ... IF EXISTS before CREATE for safe re-application.
+-- =============================================================================
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 1. Trigger function: recompute driver_details.rating for the deleted row's
+--    driver from the remaining ratings.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION recompute_driver_rating_after_rating_delete()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_new_avg NUMERIC(3,2);
+BEGIN
+  -- Only the deleted row's driver is affected.
+  SELECT ROUND(AVG(stars)::NUMERIC, 2)
+  INTO v_new_avg
+  FROM ratings
+  WHERE driver_id = OLD.driver_id;
+
+  UPDATE driver_details
+  SET rating     = v_new_avg,
+      updated_at = now()
+  WHERE user_id = OLD.driver_id;
+
+  RETURN OLD;
+END;
+$$;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 2. AFTER DELETE trigger on ratings.
+-- ─────────────────────────────────────────────────────────────────────────────
+DROP TRIGGER IF EXISTS trg_ratings_after_delete_recompute ON public.ratings;
+
+CREATE TRIGGER trg_ratings_after_delete_recompute
+  AFTER DELETE ON public.ratings
+  FOR EACH ROW
+  EXECUTE FUNCTION recompute_driver_rating_after_rating_delete();


### PR DESCRIPTION
Closes #14938.

## Problem

`submit_rating_tx` recomputes `driver_details.rating = ROUND(AVG(stars))` only on **INSERT/UPDATE**. The `Customers manage own ratings` RLS policy is `FOR ALL` (permits `DELETE` via its `USING` clause), but there was **no `AFTER DELETE` trigger**. So once a customer deleted their own rating, the stored `driver_details.rating` was never refreshed and no longer equaled `AVG(stars)` over the remaining rows — the driver's displayed rating was permanently wrong and reachable directly via PostgREST.

## Fix

New migration `supabase/migrations/20260815000000_ratings_after_delete_recompute.sql`:

- `CREATE OR REPLACE FUNCTION recompute_driver_rating_after_rating_delete()` — recomputes `ROUND(AVG(stars), 2)` from the surviving ratings for `OLD.driver_id` and writes it back to `driver_details` (`user_id = OLD.driver_id`), mirroring the INSERT/UPDATE path in `submit_rating_tx`.
- `CREATE TRIGGER trg_ratings_after_delete_recompute AFTER DELETE ON public.ratings FOR EACH ROW EXECUTE FUNCTION ...`
- Idempotent: `DROP TRIGGER IF EXISTS` before `CREATE`.
- When the last rating is deleted, `AVG()` over an empty set is `NULL`, so the driver's rating returns to its pre-rating `NULL` state (consistent with the column's default).

The trigger function is `SECURITY DEFINER` with `search_path = public, pg_temp`, matching the existing `submit_rating_tx` security posture.

## Regression test

New: `backend/api/test/unit/ratingsDeleteRecompute.test.js` (3 cases), following the repo's established migration-regression pattern (`ratingsRlsRegression.test.js` reads the migration SQL and asserts structure):

1. Defines the trigger function that recomputes `AVG(stars)` for `OLD.driver_id` from the surviving rows and writes it back to `driver_details`.
2. Wires the function to an `AFTER DELETE FOR EACH ROW` trigger on `ratings`.
3. Is idempotent (drops the trigger before creating it).

TDD-verified: all 3 **fail on `main`** (migration absent → `readFileSync` throws, the file does not load) and **pass with this fix**.

## Note

This addresses the missing DELETE recompute specifically (as scoped in #14938); it does not change the `FOR ALL` policy or the INSERT/UPDATE path. Restricting the policy to `INSERT, UPDATE` was the alternative proposed in the issue, but keeping DELETE allowed (with a correct recompute) preserves the customer's ability to remove their own rating without desyncing the average.

Note: this PR was created by an AI agent (OpenHands) on behalf of saidai-bhuvanesh.

Closes #14938.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Driver rating averages now recalculate automatically when a rating is deleted.
  - Driver ratings reset to blank when no ratings remain.
  - Related rating timestamps update to reflect recalculation.

- **Tests**
  - Added regression coverage for rating deletion, recalculation, reset behavior, and repeatable trigger setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->