### PR TITLE
fix(index): merge duplicate auth.js import

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -121,7 +121,7 @@ import { initWebRTCSignaling, closeWebRTCSignaling } from './sockets/webrtc.js'
 // ============================================================================
 import fraudRoutes from './routes/fraudRoutes.js'
 import { fraudDetectionMiddleware, networkAnalysisMiddleware } from './middleware/fraudMiddleware.js'
-import { authenticate, requireRole } from './middleware/auth.js'
+import { authenticate, requireRole, verifyJWT } from './middleware/auth.js'
 import { requireApiKey } from './middleware/apiKey.js'
 import fraudDetection from './services/fraud/FraudDetectionService.js'
 import headerSizeMonitor from './middleware/headerSizeMonitor.js';
@@ -144,7 +144,6 @@ import { setupSwagger } from './config/swagger.js'
 import { correlationIdMiddleware } from './middleware/correlationId.js'
 import { requestCacheMiddleware } from './middleware/requestCacheMiddleware.js'
 import { requireJsonContent } from './middleware/contentType.js'
-import { verifyJWT } from './middleware/auth.js'
 import { initSentry, flushSentry, sentryErrorHandler, sentryRequestHandler, captureException } from './middleware/sentry.js'
 import {
   startEscrowRefundReconciliation,


### PR DESCRIPTION
Closes #15000

## Problem
`backend/api/src/index.js` imports the same module `./middleware/auth.js` twice (lines 124 and 147), which triggers the `no-duplicate-imports` eslint warning and is redundant.

## Fix
Merged the two imports into a single line: `import { authenticate, requireRole, verifyJWT } from './middleware/auth.js'`.

GSSOC
