### PR TITLE
fix(load-test): remove redundant __ENV global comment

### DIFF
--- a/backend/api/tests/load/scenarios.js
+++ b/backend/api/tests/load/scenarios.js
@@ -1,4 +1,3 @@
-/* global __ENV */
 import http from 'k6/http';
 import { check, sleep } from 'k6';
 


### PR DESCRIPTION
Closes #15002

## Problem
`backend/api/tests/load/scenarios.js` declares `/* global __ENV */` at the top, but `__ENV` is already defined as a built-in global in `eslint.config.js`. This triggers the `no-redeclare` eslint error.

## Fix
Removed the redundant `/* global __ENV */` comment line.

GSSOC
