### PR TITLE
fix(test): merge duplicate fraudMiddleware import

### DIFF
--- a/backend/api/test/unit/fraudMiddleware.test.js
+++ b/backend/api/test/unit/fraudMiddleware.test.js
@@ -14,7 +14,7 @@ vi.mock('../../src/middleware/logger.js', () => ({
   default: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
 }));
 
-import { fraudDetectionMiddleware, networkAnalysisMiddleware } from '../../src/middleware/fraudMiddleware.js';
+import { fraudDetectionMiddleware, networkAnalysisMiddleware, clampRiskScore, accumulateRisk } from '../../src/middleware/fraudMiddleware.js';
 
 function makeReqRes(overrides = {}) {
   const req = {
@@ -96,7 +96,6 @@ describe('fraudMiddleware', () => {
 
 
 // === Spec 13 test ===
-import { clampRiskScore, accumulateRisk } from '../../src/middleware/fraudMiddleware.js';
 describe('clampRiskScore', () => {
   it('50 passes', () => { expect(clampRiskScore(50)).toBe(50); });
   it('150 → 100', () => { expect(clampRiskScore(150)).toBe(100); });


### PR DESCRIPTION
Closes #15005

## Problem
`backend/api/test/unit/fraudMiddleware.test.js` imports the same module `../../src/middleware/fraudMiddleware.js` twice (lines 17 and 99). This triggers the `no-duplicate-imports` eslint warning.

## Fix
Merged `clampRiskScore, accumulateRisk` into the existing import on line 17 and removed the duplicate import statement.

GSSOC
