### PR TITLE
fix(test): merge duplicate otpHashing import

### DIFF
--- a/backend/api/test/unit/otpHashing.test.js
+++ b/backend/api/test/unit/otpHashing.test.js
@@ -1,4 +1,4 @@
-import { hashOtp, verifyOtpHash } from '../../src/lib/otpHashing.js';
+import { hashOtp, verifyOtpHash, constantTimeEqualHex } from '../../src/lib/otpHashing.js';
 import crypto from 'crypto';
 
 describe('otpHashing', () => {
@@ -126,7 +126,6 @@ describe('otpHashing', () => {
 
 // === Spec 12 test ===
 import { describe, it, expect } from 'vitest';
-import { constantTimeEqualHex } from '../../src/lib/otpHashing.js';
 describe('constantTimeEqualHex', () => {
   it('equal returns true', () => { expect(constantTimeEqualHex('abcdef', 'abcdef')).toBe(true); });
   it('different returns false', () => { expect(constantTimeEqualHex('abcdef', '123456')).toBe(false); });


### PR DESCRIPTION
Closes #15007

## Problem
`backend/api/test/unit/otpHashing.test.js` imports the same module `../../src/lib/otpHashing.js` twice (lines 1 and 129). This triggers the `no-duplicate-imports` eslint warning.

## Fix
Merged `constantTimeEqualHex` into the existing import on line 1 and removed the duplicate import statement.

GSSOC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated OTP hashing tests to use the constant-time hexadecimal comparison utility.
  * Removed a duplicate import without changing test coverage or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->