### PR TITLE
fix(test): merge duplicate SpanFactory import

### DIFF
--- a/backend/api/test/unit/spanFactory.test.js
+++ b/backend/api/test/unit/spanFactory.test.js
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import spanFactory, { STANDARD_ATTRIBUTES } from '../../src/core/telemetry/SpanFactory.js';
-import { SPAN_NAMES } from '../../src/core/telemetry/SpanFactory.js';
+import spanFactory, { STANDARD_ATTRIBUTES, SPAN_NAMES } from '../../src/core/telemetry/SpanFactory.js';
 
 describe('SpanFactory', () => {
   describe('SPAN_NAMES', () => {


### PR DESCRIPTION
Closes #15008

## Problem
`backend/api/test/unit/spanFactory.test.js` imports the same module `../../src/core/telemetry/SpanFactory.js` twice (lines 2 and 3). This triggers the `no-duplicate-imports` eslint warning.

## Fix
Merged `SPAN_NAMES` into the existing import on line 2 and removed the duplicate import statement.

GSSOC
