### PR TITLE
fix(index): merge duplicate middleware/auth imports

### DIFF
--- a/backend/api/src/index.js
+++ b/backend/api/src/index.js
@@ -121,7 +121,7 @@ import { initWebRTCSignaling, closeWebRTCSignaling } from './sockets/webrtc.js'
 // ============================================================================
 import fraudRoutes from './routes/fraudRoutes.js'
 import { fraudDetectionMiddleware, networkAnalysisMiddleware } from './middleware/fraudMiddleware.js'
-import { authenticate, requireRole } from './middleware/auth.js'
+import { authenticate, requireRole, verifyJWT } from './middleware/auth.js'
 import { requireApiKey } from './middleware/apiKey.js'
 import fraudDetection from './services/fraud/FraudDetectionService.js'
 import headerSizeMonitor from './middleware/headerSizeMonitor.js';
@@ -144,7 +144,6 @@ import { setupSwagger } from './config/swagger.js'
 import { correlationIdMiddleware } from './middleware/correlationId.js'
 import { requestCacheMiddleware } from './middleware/requestCacheMiddleware.js'
 import { requireJsonContent } from './middleware/contentType.js'
-import { verifyJWT } from './middleware/auth.js'
 import { initSentry, flushSentry, sentryErrorHandler, sentryRequestHandler, captureException } from './middleware/sentry.js'
 import {
   startEscrowRefundReconciliation,


### PR DESCRIPTION
Closes #14987

**Problem**
`src/index.js` imports `./middleware/auth.js` twice: `authenticate, requireRole` at line 124 and `verifyJWT` at line 147. ESLint flags `no-duplicate-imports`.

**Fix**
Merged both into a single `import { authenticate, requireRole, verifyJWT } from './middleware/auth.js'` and deleted the standalone `verifyJWT` import.

GSSOC
