### PR TITLE
fix(escrow): import withLockRenewal in escrowFundingReconciliation

### DIFF
--- a/backend/api/src/services/escrowFundingReconciliation.js
+++ b/backend/api/src/services/escrowFundingReconciliation.js
@@ -1,7 +1,7 @@
 import { redisClient, supabaseAdmin } from '../config/db.js';
 import logger from '../middleware/logger.js';
 import { submitEscrowRefund, getEscrowBooking, weiWithinTolerance } from './escrow.js';
-import { acquireLock, renewLock, releaseLock } from '../lib/redisLock.js';
+import { acquireLock, renewLock, releaseLock, withLockRenewal } from '../lib/redisLock.js';
 import { sendPushNotification } from './notificationService.js';
 
 // Two-phase acceptance sweeper (#5724): orders that reached escrow_status


### PR DESCRIPTION
Closes #14988

**Problem**
`src/services/escrowFundingReconciliation.js` calls `withLockRenewal` (line 211) but never imports it, causing `ReferenceError: withLockRenewal is not defined` at runtime and a `no-undef` ESLint error. The helper is exported from `src/lib/redisLock.js` (line 128), and the file already imports `{ acquireLock, renewLock, releaseLock }` from that module (line 4).

**Fix**
Added `withLockRenewal` to the existing `../lib/redisLock.js` import.

GSSOC
