### PR TITLE
fix(test): remove duplicate guardNonNegative import

### DIFF
--- a/backend/api/test/unit/pricing.test.js
+++ b/backend/api/test/unit/pricing.test.js
@@ -245,7 +245,6 @@ describe('Pricing Service Unit Tests', () => {
 
 
 // === Spec 10 test ===
-import { guardNonNegative } from '../../src/lib/pricing.js';
 describe('guardNonNegative', () => {
   it('passes positive', () => { expect(guardNonNegative(10, 'x')).toBe(10); });
   it('clamps negative', () => { expect(guardNonNegative(-5, 'x')).toBe(0); });


### PR DESCRIPTION
Closes #15009

## Problem
`backend/api/test/unit/pricing.test.js` imports `guardNonNegative` twice from `../../src/lib/pricing.js` (line 8 and again on line 248). The duplicate import triggers a parsing error "Identifier 'guardNonNegative' has already been declared".

## Fix
Removed the duplicate import statement on line 248, since `guardNonNegative` is already imported in the main import block.

GSSOC
