### PR TITLE
fix(correlation): remove duplicate import and stray close in test

### DIFF
--- a/backend/api/test/unit/correlationId.test.js
+++ b/backend/api/test/unit/correlationId.test.js
@@ -128,7 +128,6 @@ describe('correlationIdMiddleware', () => {
 
 
 // === Spec 14 test ===
-import { correlationContext } from '../../src/middleware/correlationId.js';
 describe('correlationId context', () => {
   it('stores in run()', () => {
     correlationContext.run({ correlationId: 'cid-1' }, () => {
@@ -138,7 +137,6 @@ describe('correlationId context', () => {
   it('empty outside', () => {
     expect(correlationContext.getStore()?.correlationId).toBeUndefined();
   });
-});
 
   it('multiple nested calls maintain separate contexts', () => {
     let outerId = null;


### PR DESCRIPTION
Closes #14992

**Problem**
`test/unit/correlationId.test.js` has two parse errors:
1. `correlationContext` is imported at the top of the file and again mid-file at line 131 (`Identifier 'correlationContext' has already been declared`).
2. After removing the duplicate import, a stray `});` at line 140 (a duplicated close for the `correlationId context` describe block) leaves the `multiple nested calls maintain separate contexts` test outside any describe and the file unbalanced at EOF.

**Fix**
Deleted the mid-file duplicate import and removed the stray `});` so the describe block closes once, after the last `it`.

GSSOC
