### PR TITLE
fix(osrm): remove duplicate mid-file import in test

### DIFF
--- a/backend/api/test/unit/osrm.test.js
+++ b/backend/api/test/unit/osrm.test.js
@@ -382,7 +382,6 @@ describe('osrm - getRouteEstimate edge cases', () => {
 });
 
 // === Spec 22 test ===
-import { routeWithFailover } from '../../src/services/osrm.js';
 describe('routeWithFailover', () => {
   it('uses primary', async () => {
     const p = vi.fn().mockResolvedValue({ distance: 100, source: 'osrm' });


### PR DESCRIPTION
Closes #14994

**Problem**
`test/unit/osrm.test.js` imports `routeWithFailover` from `../../src/services/osrm.js` at the top of the file (line 22) and again mid-file at line 385 (`Parsing error: Identifier 'routeWithFailover' has already been declared`), which prevents the test file from loading.

**Fix**
Deleted the duplicate mid-file import at line 385; the top-of-file import already provides `routeWithFailover`.

GSSOC
