### PR TITLE
fix(test): remove duplicate describe import

### DIFF
--- a/backend/api/test/unit/pagination.test.js
+++ b/backend/api/test/unit/pagination.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
 function parsePage(raw) {
   const p = parseInt(raw, 10);
@@ -62,7 +62,6 @@ describe('parseLimit', () => {
     expect(parseLimit('25', 50)).toBe(25);
   });
 });
-import { describe, it, expect, vi } from 'vitest';
 import { validatePagination } from '../../src/middleware/pagination.js';
 import { buildPagination } from '../../src/utils/pagination.js';
 


### PR DESCRIPTION
Closes #15010

## Problem
`backend/api/test/unit/pagination.test.js` imports from `vitest` twice (line 1 and again on line 65). The second import redeclares `describe`, triggering a parsing error "Identifier 'describe' has already been declared" and a duplicate-import warning.

## Fix
Merged `vi` into the existing `vitest` import on line 1 and removed the duplicate import statement on line 65.

GSSOC
