### PR TITLE
fix(test): remove duplicate isValidProfile import

### DIFF
--- a/backend/api/test/unit/profileCache.test.js
+++ b/backend/api/test/unit/profileCache.test.js
@@ -38,7 +38,6 @@ describe('profileCache stats', () => {
 
 
 // === Spec 8 test ===
-import { isValidProfile } from '../../src/lib/profileCache.js';
 describe('isValidProfile', () => {
   it('accepts valid profile with required fields', () => {
     expect(isValidProfile({ id: 'a', createdAt: '2026-01-01T00:00:00Z' })).toBe(true);


### PR DESCRIPTION
Closes #15011

## Problem
`backend/api/test/unit/profileCache.test.js` imports `isValidProfile` twice from `../../src/lib/profileCache.js` (line 5 in the main import block, and again on line 41). The duplicate import triggers a parsing error "Identifier 'isValidProfile' has already been declared".

## Fix
Removed the duplicate import statement on line 41, since `isValidProfile` is already imported in the main import block.

GSSOC
