### PR TITLE
fix(notifications): repair mangled notificationService test

### DIFF
--- a/backend/api/test/unit/notificationService.test.js
+++ b/backend/api/test/unit/notificationService.test.js
@@ -33,6 +33,8 @@ const {
   sendPushNotification,
   insertNotification,
   sendDeliveryOtpNotification,
+  hashDeliveryOtp,
+  verifyDeliveryOtpHash,
 } = await import('../../src/services/notificationService.js');
 
 function okBatch(tokens) {
@@ -339,13 +341,8 @@ describe('sendPushNotification', () => {
       order_display_id: 'ORD-2001',
     });
     expect(result.success).toBe(true);
-import { sendPushNotification, sendFcmNotification } from '../../src/services/notificationService.js';
-import crypto from 'crypto';
-import { sendPushNotification, sendFcmNotification, hashDeliveryOtp, verifyDeliveryOtpHash } from '../../src/services/notificationService.js';
-import crypto from 'crypto';
-import notificationService from '../../src/services/notificationService.js';
-import { sendPushNotification, sendFcmNotification, hashDeliveryOtp, verifyDeliveryOtpHash } from '../../src/services/notificationService.js';
-import { DomainError } from '../../src/services/order/domainError.js';
+  });
+});
 
 describe('notificationService allowlist validation', () => {
   it('should throw DomainError for invalid notif_type in insertNotification', async () => {
@@ -384,14 +381,14 @@ describe('notificationService allowlist validation', () => {
 // and getUserFcmToken chains .select().eq().maybeSingle() — a mock lacking
 // either export, or with a chain shape that doesn't reach maybeSingle(),
 // makes every scenario collapse into the same early-return branch.
-const { mockFrom, mockInsert, mockSend } = vi.hoisted(() => {
+const { mockFrom, mockInsert, mockSend, mockMaybeSingle } = vi.hoisted(() => {
   const mockMaybeSingle = vi.fn().mockResolvedValue({ data: null, error: null });
   const mockEq = vi.fn(() => ({ maybeSingle: mockMaybeSingle }));
   const mockSelect = vi.fn(() => ({ eq: mockEq }));
   const mockInsert = vi.fn().mockResolvedValue({ data: { id: 'fcm-token-1' }, error: null });
   const mockFrom = vi.fn(() => ({ select: mockSelect, insert: mockInsert }));
   const mockSend = vi.fn().mockResolvedValue('mock-message-id');
-  return { mockFrom, mockInsert, mockSend };
+  return { mockFrom, mockInsert, mockSend, mockMaybeSingle };
 });
 
 vi.mock('../../src/config/db.js', () => ({


### PR DESCRIPTION
Closes #14995

**Problem**
`test/unit/notificationService.test.js` is structurally broken:
1. A mangled block of seven mid-file import statements (lines 342-348) duplicated symbols already imported at the top (e.g. `crypto` twice, `sendPushNotification` three times), causing `Parsing error: 'import' and 'export' may only appear at the top level`.
2. Removing that block revealed the `it('persists the notification row and fans out to the user's devices')` test and its enclosing `describe('sendPushNotification')` were never closed, leaving the file unbalanced at EOF.
3. Once parsing succeeded, latent runtime errors surfaced: `hashDeliveryOtp`/`verifyDeliveryOtpHash` were never imported, and `mockMaybeSingle` was used by the `sendDeliveryOtpNotification` tests but never returned from the `vi.hoisted()` factory (so it was out of scope).

**Fix**
- Deleted the mangled mid-file import block.
- Added the two missing closing braces after the fanned-out notification test.
- Added `hashDeliveryOtp` and `verifyDeliveryOtpHash` to the existing `await import(...)` destructure.
- Returned `mockMaybeSingle` from the `vi.hoisted()` factory and destructured it.

GSSOC
