### PR TITLE
fix(test): remove duplicate correlationContext import and orphaned it()

### DIFF
--- a/backend/api/test/unit/correlationId.test.js
+++ b/backend/api/test/unit/correlationId.test.js
@@ -128,7 +128,6 @@ describe('correlationIdMiddleware', () => {
 
 
 // === Spec 14 test ===
-import { correlationContext } from '../../src/middleware/correlationId.js';
 describe('correlationId context', () => {
   it('stores in run()', () => {
     correlationContext.run({ correlationId: 'cid-1' }, () => {
@@ -138,8 +137,6 @@ describe('correlationId context', () => {
   it('empty outside', () => {
     expect(correlationContext.getStore()?.correlationId).toBeUndefined();
   });
-});
-
   it('multiple nested calls maintain separate contexts', () => {
     let outerId = null;
     let innerId = null;


### PR DESCRIPTION
Closes #15019

## Problem
`backend/api/test/unit/correlationId.test.js` imports `correlationContext` twice from `../../src/middleware/correlationId.js` (line 2 and again on line 131). The duplicate import triggers a parsing error "Identifier 'correlationContext' has already been declared". Additionally, the `describe('correlationId context')` block was closed early (line 140), leaving an orphaned `it('multiple nested calls maintain separate contexts')` block that produced an "Unexpected token }" parse error.

## Fix
Removed the duplicate import statement on line 131 and moved the orphaned `it` block back inside the `describe('correlationId context')` block.

GSSOC
