### PR TITLE
fix(events): import EVENT_CATEGORIES and EventMetadata in BaseEvent test

### DIFF
--- a/backend/api/test/unit/BaseEvent.test.js
+++ b/backend/api/test/unit/BaseEvent.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { BaseEvent } from "../../src/core/events/BaseEvent.js";
+import { EVENT_CATEGORIES, EventMetadata } from "../../src/core/events/EventMetadata.js";
 
 vi.mock('../../src/middleware/logger.js', () => ({
   default: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },


### PR DESCRIPTION
Closes #14996

**Problem**
`test/unit/BaseEvent.test.js` references `EVENT_CATEGORIES.DOMAIN` and `new EventMetadata({...})` but only imports `BaseEvent`, so ESLint reports `'EVENT_CATEGORIES' is not defined` / `'EventMetadata' is not defined` (`no-undef`) and the tests crash at runtime.

**Fix**
Added `import { EVENT_CATEGORIES, EventMetadata } from "../../src/core/events/EventMetadata.js";` at the top of the file.

GSSOC
