### PR TITLE
fix(supabase-mock): close unregister_device_token block in rpc handler

### DIFF
--- a/backend/api/test/helpers/supabaseMock.js
+++ b/backend/api/test/helpers/supabaseMock.js
@@ -482,6 +482,7 @@ export function createSupabaseMock(initialStore = {}) {
           profile.fcm_token = nextActive?.fcm_token ?? null;
           profile.fcm_token_updated_at = nowIso;
         }
+      }
       // Simulate the append_maintenance_photos PL/pgSQL RPC (see
       // migrations/20260811000000_create_append_maintenance_photos.sql)
       if (fnName === 'append_maintenance_photos' && args?.p_ticket_id) {


### PR DESCRIPTION
Closes #14997

**Problem**
`test/helpers/supabaseMock.js` never closes the `if (fnName === 'unregister_device_token') { ... }` block opened at line 464. The `append_maintenance_photos` handler starts at line 487 before the block is closed, producing `Parsing error: Unexpected token ,` at line 500 and breaking the mock helper for every test that uses it.

**Fix**
Added the missing `}` after the `unregister_device_token` handler (line 484) so the block is closed before `append_maintenance_photos` is handled.

GSSOC
