### PR TITLE
fix(fraud): merge duplicate fraudMiddleware imports in test

### DIFF
--- a/backend/api/test/unit/fraudMiddleware.test.js
+++ b/backend/api/test/unit/fraudMiddleware.test.js
@@ -14,7 +14,7 @@ vi.mock('../../src/middleware/logger.js', () => ({
   default: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
 }));
 
-import { fraudDetectionMiddleware, networkAnalysisMiddleware } from '../../src/middleware/fraudMiddleware.js';
+import { fraudDetectionMiddleware, networkAnalysisMiddleware, clampRiskScore, accumulateRisk } from '../../src/middleware/fraudMiddleware.js';
 
 function makeReqRes(overrides = {}) {
   const req = {
@@ -96,7 +96,6 @@ describe('fraudMiddleware', () => {
 
 
 // === Spec 13 test ===
-import { clampRiskScore, accumulateRisk } from '../../src/middleware/fraudMiddleware.js';
 describe('clampRiskScore', () => {
   it('50 passes', () => { expect(clampRiskScore(50)).toBe(50); });
   it('150 → 100', () => { expect(clampRiskScore(150)).toBe(100); });


### PR DESCRIPTION
Closes #14999

**Problem**
`test/unit/fraudMiddleware.test.js` imports from `../../src/middleware/fraudMiddleware.js` twice: `{ fraudDetectionMiddleware, networkAnalysisMiddleware }` at the top (line 17) and `{ clampRiskScore, accumulateRisk }` mid-file (line 99). ESLint flags `no-duplicate-imports`.

**Fix**
Merged `clampRiskScore` and `accumulateRisk` into the top-of-file import and deleted the mid-file import.

GSSOC
