### PR TITLE
fix(test): remove duplicate LockState import

### DIFF
--- a/backend/api/test/unit/redisLock.test.js
+++ b/backend/api/test/unit/redisLock.test.js
@@ -24,7 +24,6 @@ describe('redisLock', () => {
 
 
 // === Spec 15 test ===
-import { LockState } from '../../src/lib/redisLock.js';
 describe('LockState', () => {
   it('acquires once', () => { const l = new LockState(); expect(l.acquire()).toBe(true); expect(l.acquire()).toBe(false); });
   it('release once ok', () => { const l = new LockState(); l.acquire(); expect(l.release()).toBe(true); });


### PR DESCRIPTION
Closes #15026

## Problem
`backend/api/test/unit/redisLock.test.js` imports `LockState` twice from `../../src/lib/redisLock.js` (line 2 and again on line 27). The duplicate import triggers a parsing error "Identifier 'LockState' has already been declared".

## Fix
Removed the duplicate import statement on line 27.

GSSOC
