### PR TITLE
fix(test): remove duplicate checkSlidingWindow import

### DIFF
--- a/backend/api/test/unit/redisRateLimiter.test.js
+++ b/backend/api/test/unit/redisRateLimiter.test.js
@@ -15,7 +15,6 @@ describe('redisRateLimiter Middleware', () => {
 
 
 // === Spec 2 test ===
-import { checkSlidingWindow } from '../../src/middleware/redisRateLimiter.js';
 describe('checkSlidingWindow', () => {
   it('allows under limit', async () => {
     const r = { eval: vi.fn().mockResolvedValue([1, 1]) };


### PR DESCRIPTION
Closes #15027

## Problem
`backend/api/test/unit/redisRateLimiter.test.js` imports `checkSlidingWindow` twice from `../../src/middleware/redisRateLimiter.js` (line 2 and again on line 18). The duplicate import triggers a parsing error "Identifier 'checkSlidingWindow' has already been declared".

## Fix
Removed the duplicate import statement on line 18.

GSSOC
