### PR TITLE
fix(test): remove duplicate EventEmitter import

### DIFF
--- a/backend/api/test/unit/requestCache.test.js
+++ b/backend/api/test/unit/requestCache.test.js
@@ -63,7 +63,6 @@ describe('RequestCache', () => {
 
 
 // === Spec 25 test ===
-import { EventEmitter } from 'node:events';
 describe('attachResponseCleanup', () => {
   it('returns a cleanup function', () => {
     const { EventEmitter } = require('node:events');


### PR DESCRIPTION
Closes #15028

## Problem
`backend/api/test/unit/requestCache.test.js` imports `EventEmitter` twice from `node:events` (line 2 and again on line 66). The duplicate import triggers a parsing error "Identifier 'EventEmitter' has already been declared".

## Fix
Removed the duplicate import statement on line 66.

GSSOC
