### PR TITLE
fix(test): remove duplicate clampGeohashPrecision import

### DIFF
--- a/backend/api/test/unit/reverseGeocode.test.js
+++ b/backend/api/test/unit/reverseGeocode.test.js
@@ -127,8 +127,6 @@ describe('reverseGeocode', () => {
   });
 });
 
-
-import { clampGeohashPrecision } from '../../src/lib/reverseGeocode.js';
 describe('clampGeohashPrecision', () => {
   it('null -> clamped to MIN 1', () => { expect(clampGeohashPrecision(null)).toBe(1); });
   it('15 -> clamped to 12', () => { expect(clampGeohashPrecision(15)).toBe(12); });


### PR DESCRIPTION
Closes #15029

## Problem
`backend/api/test/unit/reverseGeocode.test.js` imports `clampGeohashPrecision` twice from `../../src/lib/reverseGeocode.js` (line 6 and again on line 131). The duplicate import triggers a parsing error "Identifier 'clampGeohashPrecision' has already been declared".

## Fix
Removed the duplicate import statement.

GSSOC
