### PR TITLE
fix(test): remove duplicate sanitizeKey import

### DIFF
--- a/backend/api/test/unit/suspiciousRequests.test.js
+++ b/backend/api/test/unit/suspiciousRequests.test.js
@@ -14,7 +14,6 @@ describe('suspiciousRequests Middleware', () => {
 
 
 // === Spec 6 test ===
-import { sanitizeKey, sanitizeQueryParams } from '../../src/middleware/suspiciousRequests.js';
 describe('sanitizeKey', () => {
   it('rejects __proto__', () => { expect(sanitizeKey('__proto__')).toBeNull(); });
   it('rejects constructor', () => { expect(sanitizeKey('constructor')).toBeNull(); });


### PR DESCRIPTION
Closes #15030

## Problem
`backend/api/test/unit/suspiciousRequests.test.js` imports `sanitizeKey, sanitizeQueryParams` twice from `../../src/middleware/suspiciousRequests.js` (line 2 and again on line 17). The duplicate import triggers a parsing error "Identifier 'sanitizeKey' has already been declared".

## Fix
Removed the duplicate import statement.

GSSOC
