### PR TITLE
fix(test): repair mangled uploadFilename test file

### DIFF
--- a/backend/api/test/unit/uploadFilename.test.js
+++ b/backend/api/test/unit/uploadFilename.test.js
@@ -6,7 +6,6 @@
  */
 import { describe, expect, it } from 'vitest';
 import { checkContentLength, sanitizeUploadFilename } from '../../src/lib/uploadFilename.js';
-import { sanitizeUploadFilename } from '../../src/lib/uploadFilename.js';
 
 describe('sanitizeUploadFilename', () => {
   it('returns the filename unchanged when it is already safe', () => {
@@ -65,7 +64,6 @@ describe('sanitizeUploadFilename', () => {
     expect(sanitizeUploadFilename(null, 'fallback.pdf')).toBe('fallback.pdf');
     expect(sanitizeUploadFilename(undefined, 'backup.jpg')).toBe('backup.jpg');
   });
-});
 
   it('rejects Windows reserved device names regardless of extension', () => {
     expect(sanitizeUploadFilename('nul.pdf')).toBe('upload');
@@ -100,7 +98,6 @@ describe('sanitizeUploadFilename', () => {
 });
 
 // === Spec 18 test ===
-import { checkContentLength } from '../../src/lib/uploadFilename.js';
 describe('checkContentLength', () => {
   it('returns ok when content-length is within limit', () => {
     const req = { headers: { 'content-length': '1024' } };
@@ -129,7 +126,7 @@ describe('checkContentLength', () => {
     expect(result.ok).toBe(true);
     expect(result.length).toBe(0);
   });
-
+});
 
 describe('sanitizeUploadFilename - additional edge cases', () => {
   it('handles whitespace-only string as fallback', () => {


### PR DESCRIPTION
Closes #15031

## Problem
`backend/api/test/unit/uploadFilename.test.js` is mangled:
1. `sanitizeUploadFilename` is imported twice (line 8 and line 9), triggering "Identifier 'sanitizeUploadFilename' has already been declared".
2. A stray `});` prematurely closes the first `describe('sanitizeUploadFilename', ...)` block, orphaning the following `it(...)` blocks and leaving the file with a parsing error "Unexpected token }".
3. `checkContentLength` is imported again mid-file (line 102), duplicating the line 8 import.

## Fix
- Removed the duplicate `sanitizeUploadFilename` import.
- Removed the stray `});` so the remaining `it(...)` blocks stay inside the `sanitizeUploadFilename` describe.
- Removed the duplicate mid-file `checkContentLength` import.

GSSOC
