### PR TITLE
fix(test): add missing EventMetadata import in BaseEvent test

### DIFF
--- a/backend/api/test/unit/BaseEvent.test.js
+++ b/backend/api/test/unit/BaseEvent.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { BaseEvent } from "../../src/core/events/BaseEvent.js";
+import { EventMetadata, EVENT_CATEGORIES } from "../../src/core/events/EventMetadata.js";
 
 vi.mock('../../src/middleware/logger.js', () => ({
   default: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },


### PR DESCRIPTION
Closes #15032

## Problem
`backend/api/test/unit/BaseEvent.test.js` uses `EVENT_CATEGORIES` (line 14) and `EventMetadata` but neither is imported, causing `no-undef` eslint errors.

## Fix
Added the missing import: `import { EventMetadata, EVENT_CATEGORIES } from "../../src/core/events/EventMetadata.js";`

GSSOC
