### PR TITLE
fix(pagination): hoist mid-file imports in test

### DIFF
--- a/backend/api/test/unit/pagination.test.js
+++ b/backend/api/test/unit/pagination.test.js
@@ -1,4 +1,6 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import { validatePagination } from '../../src/middleware/pagination.js';
+import { buildPagination } from '../../src/utils/pagination.js';
 
 function parsePage(raw) {
   const p = parseInt(raw, 10);
@@ -62,9 +64,6 @@ describe('parseLimit', () => {
     expect(parseLimit('25', 50)).toBe(25);
   });
 });
-import { describe, it, expect, vi } from 'vitest';
-import { validatePagination } from '../../src/middleware/pagination.js';
-import { buildPagination } from '../../src/utils/pagination.js';
 
 describe('buildPagination', () => {
   it('returns defaults when no params provided', () => {


### PR DESCRIPTION
Closes #15041

**Problem**
`test/unit/pagination.test.js` has a mid-file import block (lines 65-67) that duplicates `describe`/`it`/`expect` from vitest (already imported at line 1), causing `Parsing error: Identifier 'describe' has already been declared`, while `vi`, `validatePagination`, and `buildPagination` are imported mid-file.

**Fix**
Added `vi` to the top vitest import, hoisted `validatePagination` and `buildPagination` to top-level imports, and deleted the mid-file import block.

GSSOC
