### PR TITLE
fix(pricing): remove duplicate mid-file import in test

### DIFF
--- a/backend/api/test/unit/pricing.test.js
+++ b/backend/api/test/unit/pricing.test.js
@@ -245,7 +245,6 @@ describe('Pricing Service Unit Tests', () => {
 
 
 // === Spec 10 test ===
-import { guardNonNegative } from '../../src/lib/pricing.js';
 describe('guardNonNegative', () => {
   it('passes positive', () => { expect(guardNonNegative(10, 'x')).toBe(10); });
   it('clamps negative', () => { expect(guardNonNegative(-5, 'x')).toBe(0); });


### PR DESCRIPTION
Closes #15042

**Problem**
`test/unit/pricing.test.js` imports `guardNonNegative` in the top-of-file import block and again mid-file at line 248 (`Parsing error: Identifier 'guardNonNegative' has already been declared`).

**Fix**
Deleted the duplicate mid-file import; the top-of-file import already provides `guardNonNegative`.

GSSOC
