### PR TITLE
fix(test): close unclosed error describe block in apiResponse test

### DIFF
--- a/backend/api/test/unit/apiResponse.test.js
+++ b/backend/api/test/unit/apiResponse.test.js
@@ -47,6 +47,7 @@ describe('apiResponse helpers', () => {
       const result = error('Server error', 500, undefined);
       expect(result.errors).toBeUndefined();
     });
+  });
 
   describe('paginated', () => {
     it('returns pagination metadata for page 1', () => {


### PR DESCRIPTION
Closes #15034

## Problem
`backend/api/test/unit/apiResponse.test.js` has an unclosed `describe('error', ...)` block. As a result `describe('paginated', ...)` is nested inside it and the outer `describe('apiResponse helpers')` is never closed, producing a "Parsing error: Unexpected token" at the end of file.

## Fix
Added the missing `});` to close the `describe('error', ...)` block before `describe('paginated', ...)` starts, so all three describes are siblings.

GSSOC
