### PR TITLE
fix(profile-cache): remove duplicate mid-file import in test

### DIFF
--- a/backend/api/test/unit/profileCache.test.js
+++ b/backend/api/test/unit/profileCache.test.js
@@ -38,7 +38,6 @@ describe('profileCache stats', () => {
 
 
 // === Spec 8 test ===
-import { isValidProfile } from '../../src/lib/profileCache.js';
 describe('isValidProfile', () => {
   it('accepts valid profile with required fields', () => {
     expect(isValidProfile({ id: 'a', createdAt: '2026-01-01T00:00:00Z' })).toBe(true);


### PR DESCRIPTION
Closes #15043

**Problem**
`test/unit/profileCache.test.js` imports `isValidProfile` in the top-of-file import block and again mid-file at line 41 (`Parsing error: Identifier 'isValidProfile' has already been declared`).

**Fix**
Deleted the duplicate mid-file import; the top-of-file import already provides `isValidProfile`.

GSSOC
