### PR TITLE
fix(test): define mockLogger in trafficService test

### DIFF
--- a/backend/api/test/unit/trafficService.test.js
+++ b/backend/api/test/unit/trafficService.test.js
@@ -1,8 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { getLiveTrafficMultiplier } from '../../src/services/trafficService.js';
 
+const { mockLogger } = vi.hoisted(() => ({
+  mockLogger: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+}));
+
 vi.mock('../../src/middleware/logger.js', () => ({
-  default: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  default: mockLogger,
 }));
 
 describe('trafficService', () => {


### PR DESCRIPTION
Closes #15035

## Problem
`backend/api/test/unit/trafficService.test.js` references `mockLogger` (lines 42, 52, and later) but it is never defined. The `vi.mock` factory creates a logger inline without exposing a `mockLogger` binding, causing `no-undef` eslint errors.

## Fix
Declared `mockLogger` with `vi.hoisted` and referenced it from the mock factory so the assertions can access the shared mock.

GSSOC
