### PR TITLE
fix(redis-lock): remove duplicate mid-file import in test

### DIFF
--- a/backend/api/test/unit/redisLock.test.js
+++ b/backend/api/test/unit/redisLock.test.js
@@ -24,7 +24,6 @@ describe('redisLock', () => {
 
 
 // === Spec 15 test ===
-import { LockState } from '../../src/lib/redisLock.js';
 describe('LockState', () => {
   it('acquires once', () => { const l = new LockState(); expect(l.acquire()).toBe(true); expect(l.acquire()).toBe(false); });
   it('release once ok', () => { const l = new LockState(); l.acquire(); expect(l.release()).toBe(true); });


### PR DESCRIPTION
Closes #15044

**Problem**
`test/unit/redisLock.test.js` imports `LockState` from `../../src/lib/redisLock.js` at the top (line 2) and again mid-file at line 27 (`Parsing error: Identifier 'LockState' has already been declared`), which prevents the test file from loading.

**Fix**
Deleted the duplicate mid-file import; the top-of-file import already provides `LockState`.

GSSOC
