### PR TITLE
fix(rate-limiter): remove duplicate mid-file import in test

### DIFF
--- a/backend/api/test/unit/redisRateLimiter.test.js
+++ b/backend/api/test/unit/redisRateLimiter.test.js
@@ -15,7 +15,6 @@ describe('redisRateLimiter Middleware', () => {
 
 
 // === Spec 2 test ===
-import { checkSlidingWindow } from '../../src/middleware/redisRateLimiter.js';
 describe('checkSlidingWindow', () => {
   it('allows under limit', async () => {
     const r = { eval: vi.fn().mockResolvedValue([1, 1]) };


### PR DESCRIPTION
Closes #15045

**Problem**
`test/unit/redisRateLimiter.test.js` imports `checkSlidingWindow` from `../../src/middleware/redisRateLimiter.js` at the top (line 2) and again mid-file at line 18 (`Parsing error: Identifier 'checkSlidingWindow' has already been declared`).

**Fix**
Deleted the duplicate mid-file import; the top-of-file import already provides `checkSlidingWindow`.

GSSOC
