### PR TITLE
fix(request-cache): remove duplicate mid-file import in test

### DIFF
--- a/backend/api/test/unit/requestCache.test.js
+++ b/backend/api/test/unit/requestCache.test.js
@@ -63,7 +63,6 @@ describe('RequestCache', () => {
 
 
 // === Spec 25 test ===
-import { EventEmitter } from 'node:events';
 describe('attachResponseCleanup', () => {
   it('returns a cleanup function', () => {
     const { EventEmitter } = require('node:events');


### PR DESCRIPTION
Closes #15047

**Problem**
`test/unit/requestCache.test.js` imports `EventEmitter` from `node:events` at the top (line 2) and again mid-file at line 66 (`Parsing error: Identifier 'EventEmitter' has already been declared`).

**Fix**
Deleted the duplicate mid-file import; the top-of-file import already provides `EventEmitter`.

GSSOC
