### PR TITLE
fix(reverse-geocode): remove duplicate mid-file import in test

### DIFF
--- a/backend/api/test/unit/reverseGeocode.test.js
+++ b/backend/api/test/unit/reverseGeocode.test.js
@@ -128,7 +128,6 @@ describe('reverseGeocode', () => {
 });
 
 
-import { clampGeohashPrecision } from '../../src/lib/reverseGeocode.js';
 describe('clampGeohashPrecision', () => {
   it('null -> clamped to MIN 1', () => { expect(clampGeohashPrecision(null)).toBe(1); });
   it('15 -> clamped to 12', () => { expect(clampGeohashPrecision(15)).toBe(12); });


### PR DESCRIPTION
Closes #15049

**Problem**
`test/unit/reverseGeocode.test.js` imports `clampGeohashPrecision` from `../../src/lib/reverseGeocode.js` at the top (line 7) and again mid-file at line 131 (`Parsing error: Identifier 'clampGeohashPrecision' has already been declared`).

**Fix**
Deleted the duplicate mid-file import; the top-of-file import already provides `clampGeohashPrecision`.

GSSOC
