### PR TITLE
fix(suspicious-requests): remove duplicate mid-file import in test

### DIFF
--- a/backend/api/test/unit/suspiciousRequests.test.js
+++ b/backend/api/test/unit/suspiciousRequests.test.js
@@ -14,7 +14,6 @@ describe('suspiciousRequests Middleware', () => {
 
 
 // === Spec 6 test ===
-import { sanitizeKey, sanitizeQueryParams } from '../../src/middleware/suspiciousRequests.js';
 describe('sanitizeKey', () => {
   it('rejects __proto__', () => { expect(sanitizeKey('__proto__')).toBeNull(); });
   it('rejects constructor', () => { expect(sanitizeKey('constructor')).toBeNull(); });


### PR DESCRIPTION
Closes #15050

**Problem**
`test/unit/suspiciousRequests.test.js` imports `sanitizeKey` and `sanitizeQueryParams` from `../../src/middleware/suspiciousRequests.js` at the top (line 2) and again mid-file at line 17 (`Parsing error: Identifier 'sanitizeKey' has already been declared`).

**Fix**
Deleted the duplicate mid-file import; the top-of-file import already provides both symbols.

GSSOC
