### PR TITLE
fix(upload-filename): repair mangled uploadFilename test

### DIFF
--- a/backend/api/test/unit/uploadFilename.test.js
+++ b/backend/api/test/unit/uploadFilename.test.js
@@ -6,7 +6,6 @@
  */
 import { describe, expect, it } from 'vitest';
 import { checkContentLength, sanitizeUploadFilename } from '../../src/lib/uploadFilename.js';
-import { sanitizeUploadFilename } from '../../src/lib/uploadFilename.js';
 
 describe('sanitizeUploadFilename', () => {
   it('returns the filename unchanged when it is already safe', () => {
@@ -65,7 +64,6 @@ describe('sanitizeUploadFilename', () => {
     expect(sanitizeUploadFilename(null, 'fallback.pdf')).toBe('fallback.pdf');
     expect(sanitizeUploadFilename(undefined, 'backup.jpg')).toBe('backup.jpg');
   });
-});
 
   it('rejects Windows reserved device names regardless of extension', () => {
     expect(sanitizeUploadFilename('nul.pdf')).toBe('upload');
@@ -100,7 +98,6 @@ describe('sanitizeUploadFilename', () => {
 });
 
 // === Spec 18 test ===
-import { checkContentLength } from '../../src/lib/uploadFilename.js';
 describe('checkContentLength', () => {
   it('returns ok when content-length is within limit', () => {
     const req = { headers: { 'content-length': '1024' } };
@@ -129,7 +126,7 @@ describe('checkContentLength', () => {
     expect(result.ok).toBe(true);
     expect(result.length).toBe(0);
   });
-
+});
 
 describe('sanitizeUploadFilename - additional edge cases', () => {
   it('handles whitespace-only string as fallback', () => {


### PR DESCRIPTION
Closes #15051

**Problem**
`test/unit/uploadFilename.test.js` has three structural issues:
1. `sanitizeUploadFilename` is imported twice (top block line 8 and again at line 9), triggering `Parsing error: Identifier 'sanitizeUploadFilename' has already been declared`.
2. The `sanitizeUploadFilename` describe block is closed at line 67, leaving the following five tests orphaned at top level and a stray `});` at line 99.
3. The `checkContentLength` describe block (opened line 101) is never closed before the final `sanitizeUploadFilename - additional edge cases` describe opens, and `checkContentLength` is re-imported mid-file at line 103.

**Fix**
- Deleted the duplicate `sanitizeUploadFilename` import (line 9) and the redundant mid-file `checkContentLength` import (line 103).
- Removed the premature `});` at line 67 so the five remaining tests stay inside the `sanitizeUploadFilename` describe.
- Added the missing `});` to close the `checkContentLength` describe block.

GSSOC
