### PR TITLE
fix(traffic): hoist mockLogger in trafficService test

### DIFF
--- a/backend/api/test/unit/trafficService.test.js
+++ b/backend/api/test/unit/trafficService.test.js
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { getLiveTrafficMultiplier } from '../../src/services/trafficService.js';
 
+const mockLogger = { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() };
+
 vi.mock('../../src/middleware/logger.js', () => ({
-  default: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },
+  default: mockLogger,
 }));
 
 describe('trafficService', () => {


### PR DESCRIPTION
Closes #15062

**Problem**
`test/unit/trafficService.test.js` asserts on `mockLogger.info` (lines 42, 52, 90, 91) but `mockLogger` is never defined. The `vi.mock('../../src/middleware/logger.js', ...)` factory builds the mock inline instead of referencing a hoisted `mockLogger`, so the assertions throw `ReferenceError: mockLogger is not defined` and ESLint reports `no-undef`.

**Fix**
Hoisted a `mockLogger` const and changed the `vi.mock` factory to return `{ default: mockLogger }`, matching the pattern used by other test files in the repo.

GSSOC
