### PR TITLE
fix(bids): remove duplicate submitEscrowRefund mock in contract test

### DIFF
--- a/backend/api/test/contracts/bids.contract.test.js
+++ b/backend/api/test/contracts/bids.contract.test.js
@@ -18,7 +18,6 @@ vi.mock('../../src/services/escrow.js', () => ({
   escrowDeposit: vi.fn(),
   escrowRelease: vi.fn(),
   submitEscrowRefund: vi.fn(),
-  submitEscrowRefund: vi.fn(),
   confirmEscrowRefund: vi.fn(),
   getEscrowBookingId: vi.fn((orderId) => `escrow:${orderId}`),
   ESCROW_MATIC_PER_PAISA: 0.01,


### PR DESCRIPTION
Closes #15067

**Problem**
`test/contracts/bids.contract.test.js` mocks `escrow.js` with `submitEscrowRefund: vi.fn()` declared twice (lines 20-21). Duplicate object keys are a runtime bug (last key silently wins).

**Fix**
Removed the duplicate `submitEscrowRefund` entry.

GSSOC
