### PR TITLE
fix(bids): remove duplicate submitEscrowRefund mock in integration test

### DIFF
--- a/backend/api/test/integration/bids.test.js
+++ b/backend/api/test/integration/bids.test.js
@@ -22,7 +22,6 @@ vi.mock('../../src/services/escrow.js', async () => {
     escrowDeposit: vi.fn(),
     escrowRelease: vi.fn(),
     submitEscrowRefund: vi.fn(),
-    submitEscrowRefund: vi.fn(),
     confirmEscrowRefund: vi.fn(),
     // Mirrors the real implementation's escrow:<id> booking id derivation
     getEscrowBookingId: vi.fn((orderId) => `escrow:${orderId}`),


### PR DESCRIPTION
Closes #15068

**Problem**
`test/integration/bids.test.js` mocks the order router dependencies with `submitEscrowRefund: vi.fn()` declared twice (lines 24-25). Duplicate object keys are a runtime bug (last key silently wins).

**Fix**
Removed the duplicate `submitEscrowRefund` entry.

GSSOC
