### PR TITLE
fix(domain-error): drop unused caught initializer in test

### DIFF
--- a/backend/api/test/unit/domainError.test.js
+++ b/backend/api/test/unit/domainError.test.js
@@ -45,7 +45,7 @@ describe('DomainError', () => {
 
   it('can be caught as a regular Error', () => {
     const err = new DomainError(404, { error: 'not found' })
-    let caught = false
+    let caught
     try {
       throw err
     } catch (e) {


### PR DESCRIPTION
Closes #15069

**Problem**
`test/unit/domainError.test.js` line 48 declares `let caught = false` but the initializer is never read before the variable is reassigned inside the `try` block. ESLint reports `no-useless-assignment`.

**Fix**
Declared `let caught;` without the unused initializer.

GSSOC
