### PR TITLE
fix(errors): drop unused caught initializer in test

### DIFF
--- a/backend/api/test/unit/errors.test.js
+++ b/backend/api/test/unit/errors.test.js
@@ -84,7 +84,7 @@ describe('errors', () => {
   it('all subclasses are catchable as Error', () => {
     const errs = [new NotFoundError(), new ValidationError(), new UnauthorizedError()]
     for (const err of errs) {
-      let caught = false
+      let caught
       try { throw err } catch (e) { caught = true; expect(e).toBe(err) }
       expect(caught).toBe(true)
     }


### PR DESCRIPTION
Closes #15070

**Problem**
`test/unit/errors.test.js` line 87 declares `let caught = false` but the initializer is never read before the variable is reassigned inside the loop's `try` block. ESLint reports `no-useless-assignment`.

**Fix**
Declared `let caught;` without the unused initializer.

GSSOC
