### PR TITLE
fix(cross-dock): remove invalid eslint-disable directive in test

### DIFF
--- a/backend/api/test/unit/crossDockRoutes.test.js
+++ b/backend/api/test/unit/crossDockRoutes.test.js
@@ -19,7 +19,6 @@ vi.mock('../../src/middleware/requirePolicy.js', () => ({
 // Pull in real Zod-backed validate middleware so schema validation runs
 const { validateBody: realValidateBody, validateParams: realValidateParams } = vi.hoisted(
   () => {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const m = require('../../src/middleware/validate.js');
     return { validateBody: m.validateBody, validateParams: m.validateParams };
   }


### PR DESCRIPTION
Closes #15072

**Problem**
`test/unit/crossDockRoutes.test.js` line 22 carries `// eslint-disable-next-line @typescript-eslint/no-var-requires`, but `@typescript-eslint/no-var-requires` is not a rule in this repository's ESLint configuration, so ESLint fails with `Definition for rule '@typescript-eslint/no-var-requires' was not found`.

**Fix**
Removed the invalid eslint-disable directive (the `require` call it referenced passes lint without it).

GSSOC
