### PR TITLE
fix(order-lifecycle): repair confirmDeposit parse errors

### DIFF
--- a/backend/api/src/services/order/orderLifecycleService.js
+++ b/backend/api/src/services/order/orderLifecycleService.js
@@ -961,7 +961,6 @@ export class OrderLifecycleService {
       try {
         const { data: order, error: fetchErr } = await this.orderRepository.findOrderById(
           orderId, 'id, status, order_display_id, customer_id, escrow_booking_id, escrow_status, escrow_amount_wei, escrow_driver_wallet, pending_bid_acceptance'
-          orderId, 'id, order_display_id, customer_id, escrow_booking_id, escrow_status, escrow_amount_wei, escrow_driver_wallet, pending_bid_acceptance'
         );
 
         if (fetchErr || !order) throw new DomainError(404, { error: 'Order not found' });
@@ -1021,13 +1020,14 @@ export class OrderLifecycleService {
           escrow_status: 'funded',
         });
 
-        if (updateErr) {
-          logger.error('[confirm-deposit] DB update failed:', updateErr.message);
-          throw new DomainError(500, { error: 'Database update failed after deposit confirmation. Please contact support.' });
-        }
+      if (updateErr) {
+        logger.error('[confirm-deposit] DB update failed:', updateErr.message);
+        throw new DomainError(500, { error: 'Database update failed after deposit confirmation. Please contact support.' });
+      }
+    }
 
-        // Two-phase acceptance (#5724): finalize the driver assignment now that
-        // the escrow deposit is confirmed.
+    // Two-phase acceptance (#5724): finalize the driver assignment now that
+    // the escrow deposit is confirmed.
         const pending = order.pending_bid_acceptance;
         if (pending) {
           const { error: acceptErr } = await this.orderRepository.executeRpc('accept_bid_tx', {


### PR DESCRIPTION
Closes #15073

**Problem**
`src/services/order/orderLifecycleService.js` `confirmDeposit` had two defects:
1. A duplicated argument line in the `findOrderById` call (the second `orderId, 'id, order_display_id, ...'` line repeated the call arguments without a separator), producing a parse error.
2. Once that was removed, another parse error surfaced: the failure-fallback `if (updateErr || !fundedRows || fundedRows.length === 0)` block was never closed, leaving the whole method's `try { ... } finally { ... }` misaligned and `Unexpected token 'finally'`.

**Fix**
- Deleted the duplicated argument line (keeping the superset select list that includes `status`).
- Added the missing closing brace for the `updateErr` fallback block before the two-phase acceptance section.

GSSOC
