### PR TITLE
fix(escrow-webhook): repair unloadable test file

### DIFF
--- a/backend/api/test/unit/escrowWebhookProcessor.test.js
+++ b/backend/api/test/unit/escrowWebhookProcessor.test.js
@@ -22,6 +22,24 @@ const dbState = vi.hoisted(() => ({
   updateError: null,
 }));
 
+const mockGetTransactionReceipt = vi.hoisted(() => vi.fn());
+
+vi.mock('ethers', async (importOriginal) => {
+  const actual = await importOriginal();
+  class MockJsonRpcProvider {
+    getTransaction(...args) {
+      return mockGetTransactionReceipt(...args);
+    }
+    getTransactionReceipt(...args) {
+      return mockGetTransactionReceipt(...args);
+    }
+    getBlockNumber() {
+      return 195;
+    }
+  }
+  return { ...actual, ethers: { ...actual.ethers, JsonRpcProvider: MockJsonRpcProvider } };
+});
+
 vi.mock('../../src/services/webhook/escrowVerification.js', () => ({
   EscrowVerificationError: class EscrowVerificationError extends Error {
     constructor(code, message, options = {}) {
@@ -133,6 +151,10 @@ function resetDbState() {
   dbState.walletResult = { data: null, error: null };
   dbState.replayResult = { data: null, error: null };
   dbState.updateError = null;
+}
+
+function updatePayloads() {
+  return dbState.updates.map((u) => u.payload);
 }
 
 beforeEach(() => {
@@ -428,6 +450,7 @@ describe('processEscrowWebhookEvent — WithdrawalReady / Withdrawn', () => {
 
   it('rejects a withdrawal webhook without a well-formed transaction hash (permanent)', async () => {
     dbState.orderResult = { data: makeOrder({ order_display_id: '#OD6' }), error: null };
+  });
   it('reconciles the wallet ledger exactly once for a duplicate release (no infinite DLQ re-entry, #12154)', async () => {
     // Released-before-reconcile ordering: a release Webhook re-delivered after
     // the order is already 'released' must NOT re-apply the order effect and


### PR DESCRIPTION
Closes #15074

**Problem**
`test/unit/escrowWebhookProcessor.test.js` had a parse error: the `it('rejects a withdrawal webhook without a well-formed transaction hash (permanent)')` test at line 429 was never closed, so the next test was swallowed into it and the file could not be loaded by vitest at all. Once the closing `});` was added, three hidden `no-undef` errors surfaced: `updatePayloads` (lines 452/454) and `mockGetTransactionReceipt` (line 491) were referenced but never defined.

**Fix**
- Closed the unclosed `it` block.
- Added the missing `updatePayloads()` helper (maps the recorded `dbState.updates` to their payloads).
- Defined the hoisted `mockGetTransactionReceipt` and wired `vi.mock('ethers')` so `JsonRpcProvider.getTransactionReceipt` delegates to it, mirroring the pattern already used in `escrowVerification.test.js`.

The file now loads and is lint-clean. (Note: several tests in this file encode pre-mangling expectations against the evolved processor and were failing before the mangling; that behavioural drift is out of scope for this syntax/lint fix.)

GSSOC
