### PR TITLE
fix(tracker): collapse duplicate redisClient mock keys and drop dead ebpf import

### DIFF
--- a/backend/api/src/sockets/tracker.js
+++ b/backend/api/src/sockets/tracker.js
@@ -3,7 +3,6 @@ import { mongoDb, redisClient, firebaseAdmin, supabase, supabaseAdmin } from '..
 import jwt from 'jsonwebtoken';
 import logger from '../middleware/logger.js';
 import crypto from 'crypto';
-import { ebpfLoader } from '../../../../ebpf/loader.js';
 import { createLocationEventBus } from './locationEventBus.js';
 import telemetryBuffer from './telemetryBuffer.js';
 import GpsLog from '../models/GpsLog.js';

--- a/backend/api/test/unit/tracker.test.js
+++ b/backend/api/test/unit/tracker.test.js
@@ -2088,10 +2088,7 @@ describe('handleLocationPing - broadcast to order subscribers', () => {
 
       vi.doMock('../../src/config/db.js', () => ({
         mongoDb: null,
-        redisClient: { publish: vi.fn().mockResolvedValue(1), get: redisGet, set: redisSet, del: vi.fn() },
         redisClient: { get: redisGet, set: redisSet, del: vi.fn(), publish: vi.fn().mockResolvedValue(0) },
-        redisClient: { get: redisGet, set: redisSet, del: redisDel, publish: vi.fn().mockResolvedValue(0) },
-        redisClient: { get: redisGet, set: redisSet, del: vi.fn() },
         firebaseAdmin: null,
         supabase: null,
       }));


### PR DESCRIPTION
Closes #15075

**Problem**
`test/unit/tracker.test.js` had two defects:
1. The `vi.doMock('../../src/config/db.js')` in the cache-authorization test declared the `redisClient` key four times (lines 2091-2094). Since duplicate object keys collapse at parse time, only the last one took effect — silently dropping the `publish` mock — and one of them referenced `redisDel`, which is never declared (`no-undef`).
2. `src/sockets/tracker.js` imports `{ ebpfLoader } from '../../../../ebpf/loader.js'`, a module that does not exist anywhere in the repository and whose binding is never used. This import makes the module fail to load (`Cannot find module`), so `tracker.test.js` cannot even be collected by vitest.

**Fix**
- Collapsed the four duplicate `redisClient` keys into one, keeping `get`/`set`/`del`/`publish` (this also removes the `redisDel` `no-undef`).
- Removed the dead `ebpfLoader` import from `src/sockets/tracker.js`.

The test file now loads and is lint-clean. (Remaining test failures in this file are pre-existing behavioural drift from the upstream reorganisation of `handleLocationPing`'s auth flow — they fail on `origin/main` too and are out of scope for this syntax/lint fix.)

GSSOC
