### PR TITLE
fix(trace-middleware): add shared mocks and fix error-event assertion

### DIFF
--- a/backend/api/test/unit/traceMiddleware.test.js
+++ b/backend/api/test/unit/traceMiddleware.test.js
@@ -5,33 +5,45 @@ import {
   restoreBackgroundContext,
 } from '../../src/core/telemetry/TraceMiddleware.js';
 
+const { mockReq, mockRes, mockNext, mockSpan } = vi.hoisted(() => {
+  const mockSpan = {
+    setStatus: vi.fn(),
+    recordException: vi.fn(),
+    end: vi.fn(),
+    setAttributes: vi.fn(),
+    spanContext: () => ({ traceId: 'mock-trace-id', spanId: 'mock-span-id' }),
+  };
+  const mockReq = {
+    path: '/test',
+    method: 'GET',
+    url: '/test',
+    headers: {},
+    ip: '127.0.0.1',
+    requestId: 'req-1',
+    correlationId: 'corr-1',
+  };
+  const mockRes = {
+    setHeader: vi.fn(),
+    on: vi.fn(),
+    statusCode: 200,
+  };
+  const mockNext = vi.fn();
+  return { mockReq, mockRes, mockNext, mockSpan };
+});
+
 vi.mock('../../src/tracing/tracing.js', () => ({
   default: {
     initialize: vi.fn(),
     getTracer: vi.fn(() => ({
-      startSpan: vi.fn(() => ({
-        setStatus: vi.fn(),
-        setAttributes: vi.fn(),
-        end: vi.fn(),
-        spanContext: () => ({ traceId: 'mock-trace-id', spanId: 'mock-span-id' }),
-      })),
+      startSpan: vi.fn(() => mockSpan),
     })),
   },
 }));
 
 vi.mock('../../src/core/telemetry/SpanFactory.js', () => ({
   default: {
-    startSpan: vi.fn(() => ({
-      setStatus: vi.fn(),
-      setAttributes: vi.fn(),
-      end: vi.fn(),
-      spanContext: () => ({ traceId: 'mock-trace-id', spanId: 'mock-span-id' }),
-    })),
-    startWorkerSpan: vi.fn(() => ({
-      setStatus: vi.fn(),
-      end: vi.fn(),
-      setAttributes: vi.fn(),
-    })),
+    startSpan: vi.fn(() => mockSpan),
+    startWorkerSpan: vi.fn(() => mockSpan),
     recordError: vi.fn(),
   },
   STANDARD_ATTRIBUTES: {},
@@ -138,11 +150,12 @@ describe('TraceMiddleware utilities', () => {
     const { enhancedTracingMiddleware: fn } = await import(
       '../../src/core/telemetry/TraceMiddleware.js'
     );
+    const spanFactory = (await import('../../src/core/telemetry/SpanFactory.js')).default;
     fn(mockReq, mockRes, mockNext);
     const errorCb = mockRes.on.mock.calls.find((c) => c[0] === 'error')[1];
     const testError = new Error('connection reset');
     errorCb(testError);
-    expect(mockSpan.recordException).toHaveBeenCalledWith(testError);
+    expect(spanFactory.recordError).toHaveBeenCalledWith(mockSpan, testError);
   });
 
   it('ends span on finish', async () => {


### PR DESCRIPTION
Closes #15076

**Problem**
`test/unit/traceMiddleware.test.js` referenced `mockReq`, `mockRes`, `mockNext` and `mockSpan` in the `enhancedTracingMiddleware` tests, but none of them were defined anywhere in the file (`no-undef`). The tracing/SpanFactory mocks were also inline factories that minted a brand-new span object per call, so the tests could not observe the span the middleware actually used.

**Fix**
- Hoisted shared `mockReq` (path/method/url/headers/ip/requestId/correlationId), `mockRes` (setHeader/on/statusCode), `mockNext` and `mockSpan` (setStatus/recordException/end/setAttributes/spanContext) via `vi.hoisted()`.
- Rewired the `tracing.js` and `SpanFactory.js` mocks so `startSpan`/`startWorkerSpan` return the shared `mockSpan`.
- Updated the error-event test to assert `spanFactory.recordError`, matching the current `TraceMiddleware.js` error handler (it no longer calls `span.recordException` directly).

All 22 tests in the file now pass.

GSSOC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved automated coverage for tracing middleware error handling.
  * Added validation that response errors are correctly recorded through the tracing system.
  * Standardized test scenarios to use consistent request, response, and tracing context data, improving test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->