### PR TITLE
fix: correct normalizePhone import path in unit test

### DIFF
--- a/backend/api/test/unit/normalizePhone.test.js
+++ b/backend/api/test/unit/normalizePhone.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { normalizePhone } from '../../utils/phone.js';
+import { normalizePhone } from '../../src/utils/phone.js';
 
 describe('normalizePhone', () => {
   it('normalizes E.164 format with + prefix and space', () => {


### PR DESCRIPTION
## Problem

`backend/api/test/unit/normalizePhone.test.js:2` imports `normalizePhone` from `../../utils/phone.js`, which resolves outside the `backend/api` source tree. The actual module lives at `backend/api/src/utils/phone.js`.

## Fix

Added the missing `src/` segment to the import path:

```diff
- import { normalizePhone } from '../../utils/phone.js';
+ import { normalizePhone } from '../../src/utils/phone.js';
```

## Verification

`npx vitest run test/unit/normalizePhone.test.js` — 10/10 tests pass. `node --check` and ESLint clean.

Closes #15087
