### PR TITLE
fix: correct pricing lib import path in unit test

### DIFF
--- a/backend/api/test/unit/pricingParsePositiveFloat.test.js
+++ b/backend/api/test/unit/pricingParsePositiveFloat.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { __testing } from '../../../src/lib/pricing.js';
+import { __testing } from '../../src/lib/pricing.js';
 
 const { parsePositiveFloat } = __testing;
 


### PR DESCRIPTION
## Problem

`backend/api/test/unit/pricingParsePositiveFloat.test.js:2` imports `__testing` from `../../../src/lib/pricing.js`, which resolves to `backend/src/lib/pricing.js` (outside the `backend/api` source tree). The actual module lives at `backend/api/src/lib/pricing.js`.

## Fix

Changed the import depth to `../../src/lib/pricing.js`:

```diff
- import { __testing } from '../../../src/lib/pricing.js';
+ import { __testing } from '../../src/lib/pricing.js';
```

## Verification

`npx vitest run test/unit/pricingParsePositiveFloat.test.js` — 6/6 tests pass. `node --check` and ESLint clean.

Closes #15088


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Corrected the test file import path to ensure pricing parsing tests run successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->