### PR TITLE
fix: correct kafkaHealth import path in unit test

### DIFF
--- a/backend/api/test/unit/core/health/checks/kafkaHealth.test.js
+++ b/backend/api/test/unit/core/health/checks/kafkaHealth.test.js
@@ -22,7 +22,7 @@ vi.mock('../../../../../src/core/health/HealthCheck.js', () => ({
   }),
 }));
 
-import kafkaHealth from '../../src/core/health/checks/kafkaHealth.js';
+import kafkaHealth from '../../../../../src/core/health/checks/kafkaHealth.js';
 
 describe('kafkaHealth', () => {
   const ORIGINAL_ENV = process.env;


### PR DESCRIPTION
## Problem

`backend/api/test/unit/core/health/checks/kafkaHealth.test.js:25` imports `kafkaHealth` from `../../src/core/health/checks/kafkaHealth.js`. From `test/unit/core/health/checks/` that resolves to `test/src/...` instead of `backend/api/src/...`. The import needs five levels up to reach `backend/api`.

## Fix

```diff
- import kafkaHealth from '../../src/core/health/checks/kafkaHealth.js';
+ import kafkaHealth from '../../../../../src/core/health/checks/kafkaHealth.js';
```

## Verification

`npx vitest run test/unit/core/health/checks/kafkaHealth.test.js` — 5/5 tests pass. `node --check` and ESLint clean.

Closes #15089
