### PR TITLE
fix: correct vi.mock import paths in TraceMiddleware test

### DIFF
--- a/backend/api/test/unit/core/telemetry/TraceMiddleware.test.js
+++ b/backend/api/test/unit/core/telemetry/TraceMiddleware.test.js
@@ -27,7 +27,7 @@ vi.mock('@opentelemetry/api', () => {
   };
 });
 
-vi.mock('../../../../tracing/tracing.js', () => ({
+vi.mock('../../../../src/tracing/tracing.js', () => ({
   default: {
     getTracer: vi.fn(() => ({
       startSpan: vi.fn(() => ({
@@ -40,7 +40,7 @@ vi.mock('../../../../tracing/tracing.js', () => ({
   },
 }));
 
-vi.mock('../../../../core/telemetry/SpanFactory.js', () => ({
+vi.mock('../../../../src/core/telemetry/SpanFactory.js', () => ({
   default: {
     startWorkerSpan: vi.fn(() => ({
       setStatus: vi.fn(),
@@ -51,7 +51,7 @@ vi.mock('../../../../core/telemetry/SpanFactory.js', () => ({
   STANDARD_ATTRIBUTES: {},
 }));
 
-vi.mock('../../../../core/telemetry/ContextPropagator.js', () => ({
+vi.mock('../../../../src/core/telemetry/ContextPropagator.js', () => ({
   ContextPropagator: {
     snapshot: vi.fn(() => ({ mock: 'snapshot' })),
     restore: vi.fn((snapshot, fn) => fn()),


### PR DESCRIPTION
## Problem

`backend/api/test/unit/core/telemetry/TraceMiddleware.test.js` has three `vi.mock` paths that are missing the `src/` segment. From `test/unit/core/telemetry/`, `../../../../` reaches `backend/api`, so the modules under `backend/api/src/` were not being mocked:

- line 30: `vi.mock('../../../../tracing/tracing.js', ...)` → should target `../../../../src/tracing/tracing.js`
- line 43: `vi.mock('../../../../core/telemetry/SpanFactory.js', ...)` → should target `../../../../src/core/telemetry/SpanFactory.js`
- line 54: `vi.mock('../../../../core/telemetry/ContextPropagator.js', ...)` → should target `../../../../src/core/telemetry/ContextPropagator.js`

The mocked module specifiers did not match the real module ids, so the mocks silently did not apply.

## Fix

```diff
- vi.mock('../../../../tracing/tracing.js', () => ({
+ vi.mock('../../../../src/tracing/tracing.js', () => ({
...
- vi.mock('../../../../core/telemetry/SpanFactory.js', () => ({
+ vi.mock('../../../../src/core/telemetry/SpanFactory.js', () => ({
...
- vi.mock('../../../../core/telemetry/ContextPropagator.js', () => ({
+ vi.mock('../../../../src/core/telemetry/ContextPropagator.js', () => ({
```

## Verification

`npx vitest run test/unit/core/telemetry/TraceMiddleware.test.js` — 16/16 tests pass. `node --check` and ESLint clean.

Closes #15090
