### PR TITLE
fix: correct reverseGeocode import path in unit test

### DIFF
--- a/backend/api/test/unit/reverseGeocodeClampGeohash.test.js
+++ b/backend/api/test/unit/reverseGeocodeClampGeohash.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { clampGeohashPrecision } from '../../../src/lib/reverseGeocode.js';
+import { clampGeohashPrecision } from '../../src/lib/reverseGeocode.js';
 
 describe('clampGeohashPrecision', () => {
   it('returns exact MIN boundary', () => {


### PR DESCRIPTION
## Problem

`backend/api/test/unit/reverseGeocodeClampGeohash.test.js:2` imports `clampGeohashPrecision` from `../../../src/lib/reverseGeocode.js`, which resolves to `backend/src/lib/reverseGeocode.js` (outside the `backend/api` source tree). The actual module lives at `backend/api/src/lib/reverseGeocode.js`.

## Fix

Changed the import depth to `../../src/lib/reverseGeocode.js`:

```diff
- import { clampGeohashPrecision } from '../../../src/lib/reverseGeocode.js';
+ import { clampGeohashPrecision } from '../../src/lib/reverseGeocode.js';
```

## Verification

`npx vitest run test/unit/reverseGeocodeClampGeohash.test.js` — 8/8 tests pass. `node --check` and ESLint clean.

Closes #15091
