### PR TITLE
fix: remove stray closing brace in AssetProvenance test

### DIFF
--- a/blockchain/test/AssetProvenance.test.js
+++ b/blockchain/test/AssetProvenance.test.js
@@ -62,7 +62,6 @@ describe("AssetProvenance Handoffs", function () {
     const record = await provenance.provenanceTrail(cargoHash, 0);
     expect(record.verified).to.equal(true);
   });
-});
 
   it("Should reject an unauthenticated first handoff from a non-owner", async function () {
     const [owner, stranger] = await ethers.getSigners();


### PR DESCRIPTION
## Problem

`blockchain/test/AssetProvenance.test.js` had a stray `});` after the first `it` block, which prematurely closed the `describe` block. The two remaining `it` blocks ("Should reject an unauthenticated first handoff..." and "Should allow the owner to open the trail...") were left outside the `describe`, so they would not run as part of the test suite.

## Fix

Removed the extra `});` so the `describe` block keeps the remaining test cases:

```diff
     const record = await provenance.provenanceTrail(cargoHash, 0);
     expect(record.verified).to.equal(true);
   });
-});
 
   it("Should reject an unauthenticated first handoff from a non-owner", async function () {
```

## Verification

`node --check test/AssetProvenance.test.js` — passes.

Closes #15092
