### PR TITLE
fix: correct mev.service import path in test

### DIFF
--- a/backend/mev/mev.service.test.js
+++ b/backend/mev/mev.service.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { commitHash, verifyReveal } from '../../mev.service.js';
+import { commitHash, verifyReveal } from './mev.service.js';
 describe('commit-reveal', () => {
   it('roundtrip', () => { expect(verifyReveal(commitHash('s', { a: 1 }), 's', { a: 1 })).toBe(true); });
   it('wrong', () => { expect(verifyReveal(commitHash('a', {}), 'b', {})).toBe(false); });


### PR DESCRIPTION
## Problem

`backend/mev/mev.service.test.js:2` imports `commitHash` and `verifyReveal` from `../../mev.service.js`. From `backend/mev/`, `../../` escapes the package, so the import could not be resolved. The module lives in the same directory.

## Fix

```diff
- import { commitHash, verifyReveal } from '../../mev.service.js';
+ import { commitHash, verifyReveal } from './mev.service.js';
```

## Verification

`node --check mev.service.test.js` — passes. The target module loads and exports both `commitHash` and `verifyReveal`.

Closes #15093
