### PR TITLE
fix: correct event-store import path in test_divergence

### DIFF
--- a/backend/eventsourcing/test_divergence.js
+++ b/backend/eventsourcing/test_divergence.js
@@ -30,7 +30,7 @@ console.log('✅ Divergence Detector tests passed successfully.');
 
 // === Spec 36 test ===
 import { describe, it, expect } from 'vitest';
-import { sortBySequence } from '../../event-store.js';
+import { sortBySequence } from './event-store.js';
 describe('sortBySequence', () => {
   it('asc', () => { expect(sortBySequence([{sequenceNr:3},{sequenceNr:1}]).map(e=>e.sequenceNr)).toEqual([1,3]); });
 });


### PR DESCRIPTION
## Problem

`backend/eventsourcing/test_divergence.js:33` imports `sortBySequence` from `../../event-store.js`. From `backend/eventsourcing/`, `../../` escapes the package, so the import could not be resolved. The module lives in the same directory.

## Fix

```diff
- import { sortBySequence } from '../../event-store.js';
+ import { sortBySequence } from './event-store.js';
```

## Verification

`node --check test_divergence.js` — passes. The target module exports `sortBySequence`.

Closes #15095
