### PR TITLE
fix: correct GlobalStore import path in store routes

### DIFF
--- a/backend/store/routes.js
+++ b/backend/store/routes.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import GlobalStore from './Globalreq.store.js';
+import GlobalStore from './GlobalStore.js';
 import logger from '../api/src/middleware/logger.js';
 import { authenticate } from '../api/src/middleware/auth.js';
 


### PR DESCRIPTION
## Problem

`backend/store/routes.js:2` imports `GlobalStore` from `./Globalreq.store.js`, but no such file exists. The actual module in the same directory is `GlobalStore.js`.

## Fix

```diff
- import GlobalStore from './Globalreq.store.js';
+ import GlobalStore from './GlobalStore.js';
```

## Verification

`node --check routes.js` — passes. `GlobalStore.js` exists and exports a default `GlobalStore`.

Closes #15096
