### PR TITLE
fix(test): correct WorkerEventAdapter import path in unit test

### DIFF
--- a/backend/api/test/unit/events_WorkerEventAdapter.test.js
+++ b/backend/api/test/unit/events_WorkerEventAdapter.test.js
@@ -10,7 +10,7 @@ vi.mock('../../src/core/events/EventBus.js', () => ({ EventBus: vi.fn() }));
 
 describe('WorkerEventAdapter', () => {
   it('provides a fallback class when module unavailable', async () => {
-    const { WorkerEventAdapter } = await import('../../src/core/events/WorkerEventAdapter.js');
+    const { WorkerEventAdapter } = await import('../../src/core/events/adapters/WorkerEventAdapter.js');
     expect(WorkerEventAdapter).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

Fixes `backend/api/test/unit/events_WorkerEventAdapter.test.js`, which imported the worker event adapter from `'../../src/core/events/WorkerEventAdapter.js'`. The class actually lives at `src/core/events/adapters/WorkerEventAdapter.js`, so the test failed to load with `Cannot find module` and never exercised anything.

## Change

Correct the import path to `'../../src/core/events/adapters/WorkerEventAdapter.js'`.

## Verification

- Before: `vitest run test/unit/events_WorkerEventAdapter.test.js` failed (`Error: Cannot find module '/src/core/events/WorkerEventAdapter.js'`).
- After: 1/1 tests pass.

Closes #15107


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated a test import path to reflect the adapter’s new location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->