### PR TITLE
fix(test): add isOwnershipOnlyPolicy to escort wallet route policy mock

### DIFF
--- a/backend/api/test/unit/escortWalletRoutes.test.js
+++ b/backend/api/test/unit/escortWalletRoutes.test.js
@@ -21,7 +21,7 @@ const { policyMock, PolicyErrorMock } = vi.hoisted(() => {
       this.name = 'PolicyError';
     }
   }
-  return { policyMock: { authorize: vi.fn() }, PolicyErrorMock };
+  return { policyMock: { authorize: vi.fn(), isOwnershipOnlyPolicy: () => false }, PolicyErrorMock };
 });
 
 // Mock the policy engine so the real requirePolicy middleware can be


### PR DESCRIPTION
## Summary

Fixes `backend/api/test/unit/escortWalletRoutes.test.js`. The hoisted policy mock was missing the `isOwnershipOnlyPolicy` method that the route under test calls, so the route crashed and every response came back 500 instead of the expected status codes.

## Change

Add `isOwnershipOnlyPolicy: () => false` to the hoisted policy mock.

## Verification

- Before: 4 tests failed (`expected 500 to be 403`, `expected 500 to be 201`).
- After: 4/4 tests pass.

Closes #15108
