### PR TITLE
fix(test): correct Permission import depth in unit test

### DIFF
--- a/backend/api/test/unit/Permission.test.js
+++ b/backend/api/test/unit/Permission.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { Permission } from "../../../src/core/auth/Permission.js";
+import { Permission } from "../../src/core/auth/Permission.js";
 
 describe("Permission", () => {
   it("rejects non-string action in constructor", () => {


### PR DESCRIPTION
## Summary

Fixes `backend/api/test/unit/Permission.test.js`, which imported the permission module with `'../../../src/core/auth/Permission.js'`. From `test/unit/`, `../../../` overshoots to `backend/`, so the import missed `backend/api/src/` and the test could not load:

```
Error: Cannot find module '../../../src/core/auth/Permission.js'
```

## Change

Correct the relative depth to `'../../src/core/auth/Permission.js'` (2 levels up reaches `backend/api/`).

## Verification

- Before: `vitest run test/unit/Permission.test.js` failed (`Cannot find module`).
- After: 7/7 tests pass.

Closes #15110
