### PR TITLE
fix(test): correct orderDisplayId import depth and function name

### DIFF
--- a/backend/api/test/unit/orderDisplayId.test.js
+++ b/backend/api/test/unit/orderDisplayId.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { generateOrderDisplayId, validateOrderDisplayId, parseDisplayId } from '../../../src/lib/orderDisplayId.js';
+import { generateOrderDisplayId, isValidOrderDisplayId, parseDisplayId } from '../../src/lib/orderDisplayId.js';
 
 describe('orderDisplayId.js', () => {
   describe('generateOrderDisplayId', () => {
@@ -18,16 +18,16 @@ describe('orderDisplayId.js', () => {
     });
   });
 
-  describe('validateOrderDisplayId', () => {
+  describe('isValidOrderDisplayId', () => {
     it('returns true for generated ID', () => {
       const id = generateOrderDisplayId();
-      expect(validateOrderDisplayId(id)).toBe(true);
+      expect(isValidOrderDisplayId(id)).toBe(true);
     });
 
     it('returns false for invalid format', () => {
-      expect(validateOrderDisplayId('')).toBe(false);
-      expect(validateOrderDisplayId(null)).toBe(false);
-      expect(validateOrderDisplayId(undefined)).toBe(false);
+      expect(isValidOrderDisplayId('')).toBe(false);
+      expect(isValidOrderDisplayId(null)).toBe(false);
+      expect(isValidOrderDisplayId(undefined)).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes `backend/api/test/unit/orderDisplayId.test.js`, which had two defects:

1. It imported with `'../../../src/lib/orderDisplayId.js'` — 3 levels up from `test/unit/` overshoots to `backend/`, so the module could not be found:

   ```
   Error: Cannot find module '../../../src/lib/orderDisplayId.js'
   ```

2. It imported `validateOrderDisplayId`, but `src/lib/orderDisplayId.js` exports `isValidOrderDisplayId`. Even with a fixed path, every call would fail with `validateOrderDisplayId is not a function`.

## Changes

- Correct the import depth to `'../../src/lib/orderDisplayId.js'`.
- Rename `validateOrderDisplayId` → `isValidOrderDisplayId` in the import, the describe label, and the 4 usages.

## Verification

- Before: failed (`Cannot find module`).
- After: 6/6 tests pass.

Closes #15111
