### PR TITLE
fix(test): import missing EventMetadata and EVENT_CATEGORIES in BaseEvent test

### DIFF
--- a/backend/api/test/unit/BaseEvent.test.js
+++ b/backend/api/test/unit/BaseEvent.test.js
@@ -1,5 +1,6 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { BaseEvent } from "../../src/core/events/BaseEvent.js";
+import { EventMetadata, EVENT_CATEGORIES } from "../../src/core/events/EventMetadata.js";
 
 vi.mock('../../src/middleware/logger.js', () => ({
   default: { error: vi.fn(), info: vi.fn(), warn: vi.fn(), debug: vi.fn() },


### PR DESCRIPTION
## Summary

Fixes `backend/api/test/unit/BaseEvent.test.js`, which used `EVENT_CATEGORIES` and `EventMetadata` without importing them. Both are exported from `src/core/events/EventMetadata.js` (not re-exported by `BaseEvent.js`), so 2 of the 11 tests crashed:

```
ReferenceError: EVENT_CATEGORIES is not defined
ReferenceError: EventMetadata is not defined
```

## Change

Add the missing import:

```js
import { EventMetadata, EVENT_CATEGORIES } from "../../src/core/events/EventMetadata.js";
```

## Verification

- Before: 2 tests failed with `ReferenceError`.
- After: 11/11 tests pass.

Closes #15112
