### PR TITLE
fix(otp): accept empty strings in constantTimeEqualHex

### DIFF
--- a/backend/api/src/lib/otpHashing.js
+++ b/backend/api/src/lib/otpHashing.js
@@ -53,7 +53,7 @@ export function constantTimeEqualHex(a, b) {
   // Reject non-hex input before any comparison to preserve the timing
   // guarantee for valid inputs.  Buffer.from with hex encoding silently
   // truncates at the first invalid char, so we validate upfront.
-  if (!/^[0-9a-fA-F]+$/.test(a) || !/^[0-9a-fA-F]+$/.test(b)) return false;
+  if (!/^[0-9a-fA-F]*$/.test(a) || !/^[0-9a-fA-F]*$/.test(b)) return false;
   // Pad the shorter string with null bytes so both buffers are the same length.
   // This keeps the crypto.timingSafeEqual call constant-time regardless of
   // whether the inputs differ in length.


### PR DESCRIPTION
## Summary

`constantTimeEqualHex` in `backend/api/src/lib/otpHashing.js` rejected empty strings before comparing. Its hex-validity check used `+` (`/^[0-9a-fA-F]+$/`), which requires at least one character, so `constantTimeEqualHex('', '')` returned `false` even though two empty strings are valid, equal hex strings.

The documented contract — `test/unit/otpHashingType.test.js`:

```
expected false to be true  // constantTimeEqualHex('', '') should be true
```

`constantTimeEqualHex` has no other callers in `src/`, so the only behavioral change is that the empty/empty comparison now returns `true`; every other case (non-string, invalid hex, length mismatch, different values) still returns `false`.

## Change

Loosen the hex-validity regex from `+` to `*`:

```js
if (!/^[0-9a-fA-F]*$/.test(a) || !/^[0-9a-fA-F]*$/.test(b)) return false;
```

## Verification

- Before: 1 test failed (`expected false to be true`).
- After: 20/20 tests pass; `node --check` and eslint clean.

Closes #15113
