### PR TITLE
fix(test): stub fetch in osrm edge cases and align Redis log assertions

### DIFF
--- a/backend/api/test/unit/osrm.test.js
+++ b/backend/api/test/unit/osrm.test.js
@@ -270,7 +270,7 @@ describe('osrm - getRouteEstimate', () => {
 
     expect(result).toEqual({ distanceKm: 20, durationSeconds: 900 });
     expect(fetch).toHaveBeenCalledOnce();
-    expect(mockLogger.error).toHaveBeenCalledWith('[osrm] Redis get error:', 'Redis connection refused');
+    expect(mockLogger.error).toHaveBeenCalledWith({ event: 'OSRM_REDIS_GET_ERROR', error: 'Redis connection refused' }, '[osrm] Redis get error');
   });
 
   it('returns result even when Redis set throws after successful OSRM response', async () => {
@@ -285,7 +285,7 @@ describe('osrm - getRouteEstimate', () => {
     });
 
     expect(result).toEqual({ distanceKm: 10, durationSeconds: 600 });
-    expect(mockLogger.error).toHaveBeenCalledWith('[osrm] Redis set error:', 'Redis write failed');
+    expect(mockLogger.error).toHaveBeenCalledWith({ event: 'OSRM_REDIS_SET_ERROR', error: 'Redis write failed' }, '[osrm] Redis set error');
   });
 
   it('does not cache null when OSRM returns a non-ok response', async () => {
@@ -315,6 +315,7 @@ describe('osrm - getRouteEstimate', () => {
 describe('osrm - getRouteEstimate edge cases', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubGlobal('fetch', vi.fn());
   });
 
   it('returns null for null input', async () => {


### PR DESCRIPTION
## Summary

Fixes `backend/api/test/unit/osrm.test.js`, which had four broken tests:

1. The `osrm - getRouteEstimate edge cases` describe block never stubbed the global `fetch`, unlike its sibling block, so:
   - `fetch.mockResolvedValue(...)` threw `TypeError: fetch.mockResolvedValue is not a function`
   - `expect(fetch).not.toHaveBeenCalled()` threw `TypeError: [Function fetch] is not a spy or a call to a spy!`
2. The Redis error-path assertions expected the old log signature `mockLogger.error('[osrm] Redis get error:', ...)`, but `src/services/osrm.js` logs with a structured first argument:

   ```js
   logger.error({ event: 'OSRM_REDIS_GET_ERROR', error: err && err.message }, '[osrm] Redis get error');
   ```

## Changes

- Add `vi.stubGlobal('fetch', vi.fn())` to the edge-cases `beforeEach`.
- Align the two Redis-error log assertions with the structured-object signature:
  - `{ event: 'OSRM_REDIS_GET_ERROR', error: 'Redis connection refused' }`
  - `{ event: 'OSRM_REDIS_SET_ERROR', error: 'Redis write failed' }`

## Verification

- Before: 4 tests failed.
- After: 34/34 tests pass.

Closes #15114
