### PR TITLE
fix(compression): honor empty x-no-compression header and guard missing getHeader

### DIFF
--- a/backend/api/src/config/compression.js
+++ b/backend/api/src/config/compression.js
@@ -61,7 +61,11 @@ const ALREADY_COMPRESSED = [
 export function shouldCompress(req, res) {
   // Explicit per-request opt-out. Useful for debugging and for endpoints that
   // stream, where buffering for compression would defeat the point.
-  if (req.headers['x-no-compression']) {
+  if (req.headers['x-no-compression'] !== undefined) {
+    return false;
+  }
+
+  if (typeof res.getHeader !== 'function') {
     return false;
   }
 


### PR DESCRIPTION
## Summary

`shouldCompress` in `backend/api/src/config/compression.js` had two robustness defects surfaced by `test/unit/compression.test.js`:

1. The `x-no-compression` opt-out used a truthiness check, so a request carrying the header with an empty value was still compressed. The presence of the header is the opt-out signal, regardless of its value:

   ```
   AssertionError: expected true to be false  // x-no-compression: ''
   ```

2. It called `res.getHeader('Content-Type')` unconditionally, so a response object without `getHeader` threw:

   ```
   TypeError: res.getHeader is not a function
   ```

## Changes

- Check for header presence instead of truthiness:

  ```js
  if (req.headers['x-no-compression'] !== undefined) return false;
  ```

- Guard the header lookup so `shouldCompress` returns a boolean (no throw) when `res` has no `getHeader`:

  ```js
  if (typeof res.getHeader !== 'function') return false;
  ```

## Verification

- Before: 2 tests failed.
- After: 18/18 tests pass; `node --check` and eslint clean.

Closes #15115
