### PR TITLE
fix(test): correct escrowHealth mock path and factory call convention

### DIFF
--- a/backend/api/test/unit/escrowHealth.test.js
+++ b/backend/api/test/unit/escrowHealth.test.js
@@ -1,12 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { HealthStatus } from "../../src/core/health/HealthCheck.js";
 
-vi.mock("../../../src/services/escrow.js", () => ({
+vi.mock("../../src/services/escrow.js", () => ({
   checkEscrowHealth: vi.fn(),
 }));
 
-const { checkEscrowHealth } = await import("../../../src/services/escrow.js");
-const { default: escrowHealthFactory } = await import("../../../src/core/health/checks/escrowHealth.js");
+const { checkEscrowHealth } = await import("../../src/services/escrow.js");
+const { default: escrowHealthFactory } = await import("../../src/core/health/checks/escrowHealth.js");
 
 describe("escrowHealth", () => {
   beforeEach(() => {
@@ -15,24 +15,21 @@ describe("escrowHealth", () => {
 
   it("returns HEALTHY when escrow reports connected", async () => {
     checkEscrowHealth.mockResolvedValue({ status: "connected", chainId: 137 });
-    const checkFn = escrowHealthFactory();
-    const result = await checkFn();
+    const result = await escrowHealthFactory();
     expect(result.status).toBe(HealthStatus.HEALTHY);
     expect(result.metadata.chainId).toBe(137);
   });
 
   it("returns DEGRADED when escrow is not configured", async () => {
     checkEscrowHealth.mockResolvedValue({ status: "not_configured" });
-    const checkFn = escrowHealthFactory();
-    const result = await checkFn();
+    const result = await escrowHealthFactory();
     expect(result.status).toBe(HealthStatus.DEGRADED);
     expect(result.message).toBe("not_configured");
   });
 
   it("returns UNHEALTHY when escrow reports an error", async () => {
     checkEscrowHealth.mockResolvedValue({ status: "error", error: "network timeout" });
-    const checkFn = escrowHealthFactory();
-    const result = await checkFn();
+    const result = await escrowHealthFactory();
     expect(result.status).toBe(HealthStatus.UNHEALTHY);
     expect(result.message).toBe("network timeout");
   });


### PR DESCRIPTION
## Summary

Fixes `backend/api/test/unit/escrowHealth.test.js`, which had two defects:

1. It mocked and imported the escrow service with `'../../../src/services/escrow.js'`. From `test/unit/`, `../../../` overshoots `backend/api/`, so the mock was never applied — the real `escrow.js` module loaded and `checkEscrowHealth.mockResolvedValue is not a function`.

2. It called `escrowHealthFactory()` and then `await checkFn()`, but the health-check factory (`src/core/health/checks/escrowHealth.js`) returns the result promise directly via `executeCheck`. So `checkFn is not a function`.

## Changes

- Correct the mock/import depth to `'../../src/services/escrow.js'` (and the check import to `'../../src/core/health/checks/escrowHealth.js'`).
- Call the factory directly: `const result = await escrowHealthFactory();`.

## Verification

- Before: 3 tests failed (`TypeError: checkEscrowHealth.mockResolvedValue is not a function`).
- After: 3/3 tests pass.

Closes #15116
