### PR TITLE
fix(contracts): make TaxSplitter.splitPayout idempotent per payout id

### DIFF
--- a/blockchain/contracts/ReentrantTaxAuthority.sol
+++ b/blockchain/contracts/ReentrantTaxAuthority.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+interface ITaxSplitter {
+    function splitPayout(
+        bytes32 _payoutId,
+        address _driver,
+        address _taxAuthorityWallet,
+        uint256 _totalAmount,
+        uint256 _gstRatePct,
+        uint256 _tdsRatePct
+    ) external payable returns (uint256);
+}
+
+/// @notice Test-only tax authority wallet that re-enters TaxSplitter.splitPayout
+///         with the same payout id while the original call is still mid-flight.
+///         Never used in production deployments.
+contract ReentrantTaxAuthority {
+    ITaxSplitter public splitter;
+    address public driver;
+    bytes32 public payoutId;
+    bool public attackEnabled;
+    bool public reentrySucceeded;
+
+    constructor(address splitterAddress) {
+        splitter = ITaxSplitter(splitterAddress);
+    }
+
+    /// @dev Arms the attack and funds the contract for the re-entrant payout.
+    function arm(bytes32 targetPayoutId, address targetDriver) external payable {
+        payoutId = targetPayoutId;
+        driver = targetDriver;
+        attackEnabled = true;
+    }
+
+    receive() external payable {
+        if (!attackEnabled) {
+            return;
+        }
+        attackEnabled = false;
+
+        // Re-enter with the same payout id. The result is swallowed rather than
+        // bubbled so the outer payout is not reverted by the failed attempt --
+        // the test asserts on `reentrySucceeded` instead.
+        (bool ok, ) = address(splitter).call{value: 0.1 ether}(
+            abi.encodeWithSelector(
+                ITaxSplitter.splitPayout.selector,
+                payoutId,
+                driver,
+                address(this),
+                0.1 ether,
+                uint256(12),
+                uint256(1)
+            )
+        );
+        reentrySucceeded = ok;
+    }
+}

--- a/blockchain/contracts/TaxSplitter.sol
+++ b/blockchain/contracts/TaxSplitter.sol
@@ -9,6 +9,10 @@ import "@openzeppelin/contracts/access/Ownable.sol";
  */
 contract TaxSplitter is Ownable {
 
+    /// @dev Payout ids that have already been settled. Guards against a payer
+    /// replaying the same logical payout (e.g. retrying after an RPC timeout).
+    mapping(bytes32 => bool) public processedPayouts;
+
     event TaxDeducted(bytes32 indexed payoutId, address indexed driver, uint256 gstAmount, uint256 tdsAmount, uint256 netPayout);
 
     constructor() Ownable(msg.sender) {}
@@ -25,6 +29,7 @@ contract TaxSplitter is Ownable {
         uint256 _gstRatePct,
         uint256 _tdsRatePct
     ) external payable returns (uint256 netPayout) {
+        require(!processedPayouts[_payoutId], "Payout already processed");
         require(_totalAmount > 0, "Total amount must be > 0");
         require(msg.value >= _totalAmount, "Insufficient value sent for tax split");
         require(_gstRatePct + _tdsRatePct <= 100, "Tax rates exceed 100%");
@@ -32,6 +37,10 @@ contract TaxSplitter is Ownable {
         uint256 gstAmount = (_totalAmount * _gstRatePct) / 100;
         uint256 tdsAmount = (_totalAmount * _tdsRatePct) / 100;
         netPayout = _totalAmount - gstAmount - tdsAmount;
+
+        // Checks-effects-interactions: mark the payout settled before any
+        // external call, so a reentrant call with the same id cannot pay twice.
+        processedPayouts[_payoutId] = true;
 
         // Route tax to government authority wallet
         (bool taxSent, ) = _taxAuthorityWallet.call{value: gstAmount + tdsAmount}("");

--- a/blockchain/test/TaxSplitter.test.js
+++ b/blockchain/test/TaxSplitter.test.js
@@ -107,4 +107,124 @@ describe("TaxSplitter Contract", function () {
     expect(taxAuthAfter - taxAuthBefore).to.equal(ethers.parseEther("0.13"));
     expect(await ethers.provider.getBalance(splitter.getAddress())).to.equal(0n);
   });
+
+  it("Should revert a replayed payout id instead of paying out twice", async function () {
+    const [owner, driver, taxAuth] = await ethers.getSigners();
+    const TaxSplitter = await ethers.getContractFactory("TaxSplitter");
+    const splitter = await TaxSplitter.deploy();
+
+    const payoutId = ethers.keccak256(ethers.toUtf8Bytes("PAYOUT_RETRY"));
+    const totalAmount = ethers.parseEther("1.0");
+
+    const tx = await splitter.splitPayout(
+      payoutId,
+      driver.address,
+      taxAuth.address,
+      totalAmount,
+      12,
+      1,
+      { value: totalAmount }
+    );
+    await tx.wait();
+
+    const driverAfterFirst = await ethers.provider.getBalance(driver.address);
+    const taxAuthAfterFirst = await ethers.provider.getBalance(taxAuth.address);
+
+    // The payer retries the same logical payout, e.g. after a timed-out RPC.
+    await expect(
+      splitter.splitPayout(
+        payoutId,
+        driver.address,
+        taxAuth.address,
+        totalAmount,
+        12,
+        1,
+        { value: totalAmount }
+      )
+    ).to.be.revertedWith("Payout already processed");
+
+    // Neither wallet was credited a second time.
+    expect(await ethers.provider.getBalance(driver.address)).to.equal(driverAfterFirst);
+    expect(await ethers.provider.getBalance(taxAuth.address)).to.equal(taxAuthAfterFirst);
+  });
+
+  it("Should expose processedPayouts so a payer can check before retrying", async function () {
+    const [owner, driver, taxAuth] = await ethers.getSigners();
+    const TaxSplitter = await ethers.getContractFactory("TaxSplitter");
+    const splitter = await TaxSplitter.deploy();
+
+    const payoutId = ethers.keccak256(ethers.toUtf8Bytes("PAYOUT_LOOKUP"));
+    const totalAmount = ethers.parseEther("1.0");
+
+    expect(await splitter.processedPayouts(payoutId)).to.equal(false);
+
+    const tx = await splitter.splitPayout(
+      payoutId,
+      driver.address,
+      taxAuth.address,
+      totalAmount,
+      12,
+      1,
+      { value: totalAmount }
+    );
+    await tx.wait();
+
+    expect(await splitter.processedPayouts(payoutId)).to.equal(true);
+  });
+
+  it("Should still process a distinct payout id after an earlier one settled", async function () {
+    const [owner, driver, taxAuth] = await ethers.getSigners();
+    const TaxSplitter = await ethers.getContractFactory("TaxSplitter");
+    const splitter = await TaxSplitter.deploy();
+
+    const totalAmount = ethers.parseEther("1.0");
+    const firstId = ethers.keccak256(ethers.toUtf8Bytes("PAYOUT_SEQ_1"));
+    const secondId = ethers.keccak256(ethers.toUtf8Bytes("PAYOUT_SEQ_2"));
+
+    await (await splitter.splitPayout(
+      firstId, driver.address, taxAuth.address, totalAmount, 12, 1, { value: totalAmount }
+    )).wait();
+
+    const taxAuthBefore = await ethers.provider.getBalance(taxAuth.address);
+
+    // A different payout id is unrelated and must go through normally.
+    await (await splitter.splitPayout(
+      secondId, driver.address, taxAuth.address, totalAmount, 12, 1, { value: totalAmount }
+    )).wait();
+
+    const taxAuthAfter = await ethers.provider.getBalance(taxAuth.address);
+    expect(taxAuthAfter - taxAuthBefore).to.equal(ethers.parseEther("0.13"));
+    expect(await splitter.processedPayouts(secondId)).to.equal(true);
+  });
+
+  it("Should block a tax-authority re-entrancy replay of the in-flight payout id", async function () {
+    const [owner, driver] = await ethers.getSigners();
+    const TaxSplitter = await ethers.getContractFactory("TaxSplitter");
+    const splitter = await TaxSplitter.deploy();
+
+    const ReentrantTaxAuthority = await ethers.getContractFactory("ReentrantTaxAuthority");
+    const attacker = await ReentrantTaxAuthority.deploy(await splitter.getAddress());
+
+    const payoutId = ethers.keccak256(ethers.toUtf8Bytes("PAYOUT_REENTRANT"));
+    const totalAmount = ethers.parseEther("1.0");
+
+    // Fund the attacker so its re-entrant call can carry its own msg.value.
+    await (await attacker.arm(payoutId, driver.address, { value: ethers.parseEther("1.0") })).wait();
+
+    const driverBefore = await ethers.provider.getBalance(driver.address);
+    await (await splitter.splitPayout(
+      payoutId,
+      driver.address,
+      await attacker.getAddress(),
+      totalAmount,
+      12,
+      1,
+      { value: totalAmount }
+    )).wait();
+    const driverAfter = await ethers.provider.getBalance(driver.address);
+
+    // The re-entrant call hit the guard, so the driver was paid exactly once.
+    expect(await attacker.reentrySucceeded()).to.equal(false);
+    expect(driverAfter - driverBefore).to.equal(ethers.parseEther("0.87"));
+  });
 });


### PR DESCRIPTION
Fixes #14848

## Root cause

`splitPayout` accepts `_payoutId` but never does anything with it except pass it to the event on the last line:

```solidity
emit TaxDeducted(_payoutId, _driver, gstAmount, tdsAmount, netPayout);
```

There is no storage that records which ids have been settled, and therefore no check that can reject a repeat. Every one of the `require`s in the function validates the *arguments* (`_totalAmount > 0`, `msg.value >= _totalAmount`, rates `<= 100`) — a resubmission of an already-settled payout satisfies all of them, because it is byte-for-byte the same call that succeeded the first time. So the two external transfers run again unconditionally.

The realistic trigger is not an attacker, it is an ordinary retry: the payer broadcasts, the RPC times out before returning a receipt, the payer resubmits the same payout. Both the driver and the tax authority get paid a second time out of the payer's own funds, and the backend's `TaxDeducted` stream now has two settlement events for one logical payout.

The same gap makes the function re-entrant. Tax is routed *before* the driver is paid:

```solidity
(bool taxSent, ) = _taxAuthorityWallet.call{value: gstAmount + tdsAmount}("");   // hands control to an arbitrary address
...
(bool driverSent, ) = _driver.call{value: netPayout}("");
```

`.call` forwards all remaining gas, so a contract at `_taxAuthorityWallet` can call straight back into `splitPayout` with the id that is still in flight.

## The fix

`blockchain/contracts/TaxSplitter.sol` — one mapping and two lines:

```solidity
mapping(bytes32 => bool) public processedPayouts;
...
require(!processedPayouts[_payoutId], "Payout already processed");   // check
...
processedPayouts[_payoutId] = true;                                  // effect, before the calls
(bool taxSent, ) = _taxAuthorityWallet.call{...}("");                // interactions
```

The write is placed before the external calls rather than next to the `emit`, so checks-effects-interactions holds and a re-entrant call with the in-flight id hits the guard instead of a stale `false`. The mapping is `public` so a payer that lost its receipt can read `processedPayouts(id)` and decide whether to retry, rather than finding out by double-paying.

Deliberately unchanged: the issue's sketch shows `onlyOwner` on the function, but the deployed signature has no such modifier, so I left access control alone — see the note at the bottom.

## Proof

The four new tests were written first and run against the **unmodified** contract. Full output, `npx hardhat test`:

```
  TaxSplitter Contract
    ✔ Should calculate and route tax split percentages correctly on payout
    ✔ Should revert when combined tax rates exceed 100%
    ✔ Should route 100% to tax authority and leave driver with zero payout
    ✔ Should refund excess msg.value sent beyond the total amount
    1) Should revert a replayed payout id instead of paying out twice
    2) Should expose processedPayouts so a payer can check before retrying
    3) Should still process a distinct payout id after an earlier one settled
    4) Should block a tax-authority re-entrancy replay of the in-flight payout id

  4 passing
  4 failing

  1) Should revert a replayed payout id instead of paying out twice:
     AssertionError: Expected transaction to be reverted with reason
     'Payout already processed', but it didn't revert

  4) Should block a tax-authority re-entrancy replay of the in-flight payout id:
     AssertionError: expected true to equal false     // attacker.reentrySucceeded()
```

Failure 4 is the re-entrancy: `ReentrantTaxAuthority` (a test-only helper in the style of the existing `ReentrantDriver.sol`) re-enters from `receive()` and, on `main`, **succeeds**.

To quantify the money involved, a throwaway script submitting the same id three times against the unmodified contract — 1.0 ETH payout, 12% GST + 1% TDS:

```
submit #1 of payout id PAYOUT_ORDER_909: OK
submit #2 of payout id PAYOUT_ORDER_909: OK
submit #3 of payout id PAYOUT_ORDER_909: OK
driver received total : 2.61 ETH  (expected 0.87)
taxAuthority received : 0.39 ETH  (expected 0.13)
```

Three submissions, three payouts, 3× the money. With this patch applied, the same script:

```
submit #1 of payout id PAYOUT_ORDER_909: OK
submit #2 of payout id PAYOUT_ORDER_909: reverted
submit #3 of payout id PAYOUT_ORDER_909: reverted
driver received total : 0.87 ETH  (expected 0.87)
taxAuthority received : 0.13 ETH  (expected 0.13)
```

And the committed suite, with the patch:

```
  TaxSplitter Contract
    ✔ Should calculate and route tax split percentages correctly on payout
    ✔ Should revert when combined tax rates exceed 100%
    ✔ Should route 100% to tax authority and leave driver with zero payout
    ✔ Should refund excess msg.value sent beyond the total amount
    ✔ Should revert a replayed payout id instead of paying out twice
    ✔ Should expose processedPayouts so a payer can check before retrying
    ✔ Should still process a distinct payout id after an earlier one settled
    ✔ Should block a tax-authority re-entrancy replay of the in-flight payout id

  8 passing
```

The four pre-existing tests are untouched and still pass, including the excess-refund test from #11534 — the new state write sits between the rate maths and the transfers, so the refund path is unaffected.

## On CI, and how these runs were produced

`Smart contract checks` cannot go green on this PR, and does not go green on `main` either. Three independent pre-existing breakages, none of them introduced here and none fixable from a contract PR:

1. `npm ci` in `blockchain/` fails outright — `@nomicfoundation/hardhat-ignition@^3.1.8` peer-requires `hardhat@^3` while the project is on `hardhat@^2.28.6`. The job dies at the install step, before compile.
2. `hardhat.config.cjs` pins solc to `0.8.20`, but a large set of contracts and their OpenZeppelin dependencies declare `pragma ^0.8.21`/`^0.8.22`/`^0.8.24` (`TruxifyUpgradeable.sol`, `StateChannel.sol`, `SubstrateBridge.sol`, `UUPSProxy.sol`, `Escrow.sol`, `Reputation.sol`, …). `npx hardhat compile` fails with `HH606` on a pristine checkout of `main`.
3. With a 0.8.24 compiler available, compilation then fails in `contracts/ZKCP.sol:40` — `Wrong argument count for struct constructor: 6 arguments given but expected 7`.

I verified 2 and 3 by stashing my changes and compiling `upstream/main` untouched; the errors are byte-identical.

So the runs above were produced against an out-of-tree Hardhat config that supplies a `0.8.24` compiler alongside `0.8.20` and points `sources` at `TaxSplitter.sol` + the test helper, which is enough to get past the project-wide compile failure. **Nothing about that harness is committed** — this PR changes exactly three files, and `TaxSplitter.sol` itself compiles cleanly under the repo's own `0.8.20` pin, since it declares `pragma ^0.8.20`. Happy to split items 1–3 into their own issues if that is useful.

## One thing to flag

The mapping is a single global id namespace, as the issue specifies, but `splitPayout` is `external payable` with **no** `onlyOwner` — anyone can call it. So a stranger can now burn a future payout id by settling a 1-wei payout to themselves, and the real payout is then permanently blocked. Verified:

```
stranger burned the id for 1 wei: OK (permissionless)
processedPayouts[id] = true
legitimate payout afterwards: BLOCKED
```

This is inherent to deduplicating on a caller-supplied key in a permissionless function, and it is not a regression — today the same stranger can already emit forged `TaxDeducted` events to poison the backend's indexer. Fixing it properly means either gating `splitPayout` behind `onlyOwner` (which the issue's own sketch assumes, and which the contract's existing `Ownable` inheritance suggests was the intent) or namespacing the mapping by `msg.sender`. Both change the contract's access-control or public-API semantics beyond what this issue asks for, so I have left them out. Glad to follow up with whichever you prefer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate payout settlement by rejecting previously processed payout IDs.
  * Added protection against re-entrant attempts to replay an in-progress payout.
  * Ensured driver payments and related transfers occur only once per payout.

* **Tests**
  * Added coverage for replay protection, re-entrancy prevention, processed payout tracking, and independent payout IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->