### PR TITLE
fix(supabase): set search_path on revoke_tracking_tokens_on_terminal_status (fixes #13962)

### DIFF
--- a/backend/api/test/unit/revokeTrackingTokensSearchPath.test.js
+++ b/backend/api/test/unit/revokeTrackingTokensSearchPath.test.js
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Regression test for issue #13962: `revoke_tracking_tokens_on_terminal_status`
+// is a SECURITY DEFINER trigger function that runs on order updates and executes
+// unqualified `update tracking_tokens ...` statements. It must pin `search_path`
+// to `public, pg_temp` to prevent search_path shadowing / privilege escalation.
+describe('revoke_tracking_tokens_on_terminal_status pins search_path (issue #13962)', () => {
+  const definingMigration = readFileSync(
+    path.resolve(
+      __dirname,
+      '../../../../supabase/migrations/20260716000000_add_public_tracking_tokens.sql'
+    ),
+    'utf8'
+  );
+
+  const hardeningMigration = readFileSync(
+    path.resolve(
+      __dirname,
+      '../../../../supabase/migrations/20260809000004_set_search_path_on_remaining_definer_functions.sql'
+    ),
+    'utf8'
+  );
+
+  it('pins search_path in the defining migration definition', () => {
+    expect(definingMigration).toMatch(
+      /create\s+or\s+replace\s+function\s+revoke_tracking_tokens_on_terminal_status\s*\(\s*\)[\s\S]*?security\s+definer\s+set\s+search_path\s*=\s*public,\s*pg_temp/i
+    );
+  });
+
+  it('pins search_path via ALTER FUNCTION in the hardening migration', () => {
+    expect(hardeningMigration).toMatch(
+      /ALTER\s+FUNCTION\s+public\.revoke_tracking_tokens_on_terminal_status\s*\(\s*\)\s*SET\s+search_path\s*=\s*public,\s*pg_temp/i
+    );
+  });
+});

--- a/supabase/migrations/20260716000000_add_public_tracking_tokens.sql
+++ b/supabase/migrations/20260716000000_add_public_tracking_tokens.sql
@@ -73,6 +73,7 @@ create or replace function revoke_tracking_tokens_on_terminal_status()
 returns trigger
 language plpgsql
 security definer
+set search_path = public, pg_temp
 as $$
 begin
   if new.status in ('delivered', 'cancelled', 'payment_released') then


### PR DESCRIPTION
## Description
Hardens the `revoke_tracking_tokens_on_terminal_status` `SECURITY DEFINER` trigger function by pinning `set search_path = public, pg_temp` directly in its defining migration (`supabase/migrations/20260716000000_add_public_tracking_tokens.sql`). Adds regression tests in `backend/api/test/unit/revokeTrackingTokensSearchPath.test.js` to ensure `search_path` shadowing and privilege escalation vulnerabilities are prevented.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?
- **Test Commands:** `node --check backend/api/test/unit/revokeTrackingTokensSearchPath.test.js` / `npm test -- test/unit/revokeTrackingTokensSearchPath.test.js`
- **Test Steps / Prerequisites:** Verified migration source AST/regex patterns guaranteeing `revoke_tracking_tokens_on_terminal_status` sets `search_path = public, pg_temp` in its defining migration and hardening migration.
- **Expected Result:** Function definitions and migrations enforce strict `search_path` pinning.

### Test Environment
- [x] Local manual testing
- [x] Unit / Integration tests (`npm test`)

## Related Issues
Closes #13962

## PR Checklist
- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.
- [x] All automated integration & unit tests pass cleanly.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved protection for tracking-token revocation by restricting the database function’s schema search path.
  * Added defense-in-depth hardening to ensure consistent behavior across migrations.

* **Tests**
  * Added regression coverage verifying the security configuration remains correctly applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->