### PR TITLE
fix: scope gps_offline_data_service_policy to service_role, revoke anon

### DIFF
--- a/supabase/migrations/20260821120000_fix_gps_offline_data_rls_scoping.sql
+++ b/supabase/migrations/20260821120000_fix_gps_offline_data_rls_scoping.sql
@@ -1,0 +1,23 @@
+-- Fix P1 security issue: gps_offline_data PUBLIC FOR ALL policy
+-- defeats owner-scoped RLS.
+--
+-- Problem: migration 20260805000060 creates gps_offline_data_service_policy
+-- with no TO clause, so it applies to PUBLIC. RLS policies are OR'd, so the
+-- PUBLIC allow-all policy wins for any authenticated user, defeating the
+-- owner-scoped gps_offline_data_owner policy. Any authenticated user can
+-- read/modify/delete any other user's GPS payloads.
+--
+-- Fix: drop the PUBLIC policy, re-create it scoped to service_role only.
+-- Also revoke anon privileges on this table (should never have been granted).
+
+-- Drop the mis-scoped PUBLIC policy
+DROP POLICY IF EXISTS gps_offline_data_service_policy ON gps_offline_data;
+
+-- Re-create scoped to service_role only (the WebRTC service uses the
+-- service/client key, not the user's JWT)
+CREATE POLICY gps_offline_data_service_policy ON gps_offline_data
+  FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+-- Revoke anon access (the table contains sensitive GPS payloads)
+REVOKE ALL ON TABLE gps_offline_data FROM anon;


### PR DESCRIPTION
## Summary

Scopes gps_offline_data_service_policy to service_role and revokes anon access on gps_offline_data.

## Problem

Migration 20260805000060 creates gps_offline_data_service_policy with no TO clause, so it applies to PUBLIC. RLS policies are OR'd, so this allow-all policy defeats the owner-scoped gps_offline_data_owner policy. Any authenticated user can read/modify/delete any other user's GPS payloads.

## Fix

Drop the mis-scoped PUBLIC policy, re-create it TO service_role only, and revoke anon privileges. The WebRTC service uses the service/client key, so service_role is the correct target.

Closes #9876

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Restricted offline GPS data access to authorized service operations.
  * Removed public access and revoked anonymous permissions for improved data protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->