### PR TITLE
fix(driver): handle { loads } envelope and bare lists in MarketplaceRepository (fixes #13310)

### DIFF
--- a/apps/driver/lib/services/marketplace_repository.dart
+++ b/apps/driver/lib/services/marketplace_repository.dart
@@ -114,8 +114,10 @@ class MarketplaceRepository {
   /// `GET /api/orders/load-offers/en-route`. An envelope without a `loads`
   /// key resolves to an empty list.
   static List<dynamic> _unwrapLoads(dynamic decoded) {
-    if (decoded is Map<String, dynamic>) {
-      return decoded['loads'] as List? ?? const [];
+    if (decoded is Map) {
+      final loads = decoded['loads'];
+      if (loads is List) return loads;
+      if (loads == null) return const [];
     }
     if (decoded is List) return decoded;
     throw StateError('Unexpected response type');

--- a/apps/driver/test/marketplace_repository_test.dart
+++ b/apps/driver/test/marketplace_repository_test.dart
@@ -172,6 +172,16 @@ void main() {
       expect(loads.first.id, 'load-1');
       expect(loads.first.customer, 'Acme Corp');
     });
+
+    test('returns empty list when en-route envelope has no loads key', () async {
+      final client = MockClient((request) async {
+        return http.Response('{"total": 0}', 200);
+      });
+
+      final loads = await _repository(client).fetchEnRouteLoads();
+
+      expect(loads, isEmpty);
+    });
   });
 
   group('MarketplaceRepository.submitBid', () {


### PR DESCRIPTION
## Description
Updates `MarketplaceRepository._unwrapLoads` in the driver application (`apps/driver/lib/services/marketplace_repository.dart`) to safely parse both the paginated `{ loads: [...] }` envelope returned by `GET /api/orders/load-offers` / `GET /api/orders/load-offers/en-route` and bare lists. Resolves runtime `StateError('Unexpected response type')` exceptions across all `Map` types and adds unit tests in `apps/driver/test/marketplace_repository_test.dart`.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Refactoring (code cleanup, performance, or structural changes)
- [ ] Documentation update
- [ ] CI/CD / DevOps / Infrastructure updates

## How Has This Been Tested?
- **Test Commands:** `flutter test test/marketplace_repository_test.dart`
- **Test Steps / Prerequisites:** Validated response decoding with `{ loads: [...] }` envelopes, empty `{ total: 0 }` envelopes, and bare `[...]` arrays for `fetchLoadOffers` and `fetchEnRouteLoads`.
- **Expected Result:** Responses unwrap into parsed `List<LoadOffer>` without throwing `StateError`.

### Test Environment
- [x] Local manual testing
- [x] Unit / Integration tests (`flutter test`)

## Related Issues
Closes #13310

## PR Checklist
- [x] My code follows the code style guidelines of this project (`flutter analyze`).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated corresponding documentation if applicable.
- [x] My changes generate no new warnings or console errors.
- [x] All automated integration & unit tests pass cleanly.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of marketplace responses when load data is missing or null.
  - En-route load requests now return an empty list instead of failing when the response lacks a `loads` field.

- **Tests**
  - Added coverage for responses without a `loads` field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->